### PR TITLE
show subscription warning on past_due

### DIFF
--- a/packages/app/src/react/features/data-space/dialogs/addNamespace.tsx
+++ b/packages/app/src/react/features/data-space/dialogs/addNamespace.tsx
@@ -98,23 +98,23 @@ export default function AddNamespaceDialog({
           isUserAcknowledged: true,
         }),
       });
+
       const responseData = await res.json();
 
       try {
         let parsedMessage = JSON.parse(responseData?.message);
-
         if (parsedMessage && parsedMessage.warnings && Array.isArray(parsedMessage.warnings)) {
-          localStorage.setItem(
-            'subscription_warnings',
-            JSON.stringify({ data: Date.now(), warnings: parsedMessage.warnings }),
-          );
+          toast.warning(parsedMessage.warnings.join('\n'));
+        } else {
+          toast.success('Your subscription has been updated.');
         }
       } catch {
         // do nothing
+        toast.success('Your subscription has been updated.');
       }
-
+      await new Promise((resolve) => setTimeout(resolve, 2000));
       await refreshUserData();
-      window.location.href = '/my-plan?upgraded=true';
+      setTimeout(() => navigateTo('/my-plan', false), 500);
     } catch (error) {
       const errorMessage = extractError(error);
       toast.error(errorMessage || 'Something went wrong. Please try again.');

--- a/packages/app/src/react/features/subscriptions/pages/EnterpriseTierFrameV4.tsx
+++ b/packages/app/src/react/features/subscriptions/pages/EnterpriseTierFrameV4.tsx
@@ -236,20 +236,18 @@ export const EnterpriseTierFrameV4: FC<Props> = ({ tierIndex }) => {
 
       try {
         let parsedMessage = JSON.parse(responseData?.message);
-
         if (parsedMessage && parsedMessage.warnings && Array.isArray(parsedMessage.warnings)) {
-          localStorage.setItem(
-            'subscription_warnings',
-            JSON.stringify({ data: Date.now(), warnings: parsedMessage.warnings }),
-          );
+          toast.warning(parsedMessage.warnings.join('\n'));
+        } else {
+          toast.success('Your subscription has been updated.');
         }
       } catch {
         // do nothing
+        toast.success('Your subscription has been updated.');
       }
-
+      await new Promise((resolve) => setTimeout(resolve, 2000));
       await refreshUserData();
-
-      window.location.href = '/my-plan?upgraded=true';
+      setTimeout(() => navigateTo('/my-plan', false), 500);
       setShowConfirmationDialog(false);
     } catch (error) {
       const errorMessage = extractError(error);

--- a/packages/app/src/react/features/subscriptions/pages/MyPlanPage.tsx
+++ b/packages/app/src/react/features/subscriptions/pages/MyPlanPage.tsx
@@ -9,7 +9,6 @@ import { extractError } from '@src/react/shared/utils/errors';
 import { convertToGB, formatNumber } from '@src/react/shared/utils/format';
 import { Analytics } from '@src/shared/posthog/services/analytics';
 import { useEffect, useMemo, useState } from 'react';
-import { useLocation, useNavigate } from 'react-router-dom';
 import { toast } from 'react-toastify';
 
 /**
@@ -55,9 +54,6 @@ const MyPlanPage = () => {
 
   const [loadingUpgrade, setLoadingUpgrade] = useState<boolean>(false);
   const [dataPoolProgress, setDataPoolProgress] = useState<number>(0);
-
-  const location = useLocation();
-  const navigate = useNavigate();
 
   useEffect(() => {
     if (userSubs) {
@@ -105,26 +101,6 @@ const MyPlanPage = () => {
       fetchData();
     }
   }, [user?.id, userSubs]);
-
-  useEffect(() => {
-    const params = new URLSearchParams(location.search);
-    const subscriptionWarnings = localStorage.getItem('subscription_warnings');
-    let isWarningsShown = false;
-    if (subscriptionWarnings) {
-      const parsedWarnings = JSON.parse(subscriptionWarnings);
-      if (parsedWarnings.data > Date.now() - 1000 * 60 * 2) {
-        toast.warning(parsedWarnings.warnings.join('\n'));
-        isWarningsShown = true;
-      }
-      localStorage.removeItem('subscription_warnings');
-    }
-    if (params.get('upgraded') === 'true' && !isWarningsShown) {
-      toast.success('Your subscription has been updated.');
-      // Remove the query parameter from the URL
-      params.delete('upgraded');
-      navigate({ search: params.toString() }, { replace: true });
-    }
-  }, [location, navigate]);
 
   const handleUnsubscribe = async (type: 'cancel' | 'restart') => {
     if (isReadOnlyAccess) return;

--- a/packages/app/src/react/features/subscriptions/pages/PlansPricingPage.tsx
+++ b/packages/app/src/react/features/subscriptions/pages/PlansPricingPage.tsx
@@ -109,18 +109,18 @@ const PricingTierItem: FC<PricingTier> = ({
 
       try {
         let parsedMessage = JSON.parse(responseData?.message);
-
         if (parsedMessage && parsedMessage.warnings && Array.isArray(parsedMessage.warnings)) {
-          localStorage.setItem(
-            'subscription_warnings',
-            JSON.stringify({ data: Date.now(), warnings: parsedMessage.warnings }),
-          );
+          toast.warning(parsedMessage.warnings.join('\n'));
+        } else {
+          toast.success('Your subscription has been updated.');
         }
       } catch {
         // do nothing
+        toast.success('Your subscription has been updated.');
       }
+      await new Promise((resolve) => setTimeout(resolve, 2000));
       await refreshUserData();
-      window.location.href = '/my-plan?upgraded=true';
+      setTimeout(() => navigateTo('/my-plan', false), 500);
       setShowConfirmationDialog(false);
     } catch (error) {
       const errorMessage = extractError(error);


### PR DESCRIPTION
If subscription end up with warning then that warning is shown instead of showing success message always.

https://app.clickup.com/t/86etju18m

Dependency PR
https://github.com/SmythOS/smyth-middleware/pull/281



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Subscription warnings are now displayed to users after changing their payment plan, if applicable.
  * Warning messages are shown with priority over success notifications when navigating to the subscription plan page.

* **Bug Fixes**
  * Improved handling of subscription plan change responses to ensure users receive timely and relevant warnings.

* **Chores**
  * Removed upgrade notification URL handling from the plan page for a cleaner user experience.
  * Updated navigation to the subscription plan page to use delayed and smoother transitions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->