### PR TITLE
Fix: 86eubqjzr :  Builder/Test Sidebar - Debugger Messages Overlap with Test Sidebar

### DIFF
--- a/packages/app/static/css/smyth-builder.css
+++ b/packages/app/static/css/smyth-builder.css
@@ -2604,3 +2604,26 @@ body.locked #tooltip-deploy-locked {
 #canvas-search-container .underline {
   text-decoration: underline;
 }
+
+/* Debug Switcher Message Positioning - Pure CSS Solution */
+/* Modern browsers: When embodiment sidebar is open (using :has() to detect from body level) */
+body:has(#right-container.open #embodiment-sidebar:not(.hidden)) .debug-switcher-message:not(.hidden) {
+  transform: translateX(-180px);
+  /* Standard translation (-translate-x-45 = -180px) */
+}
+
+/* Pure CSS: When embodiment sidebar is open AND no upgrade button exists */
+body:not(:has(#upgrade-button-topbar)):has(#right-container.open #embodiment-sidebar:not(.hidden)) .debug-switcher-message:not(.hidden) {
+  transform: translateX(-268px);
+  /* Additional 88px translation = total -268px */
+}
+
+/* Pure CSS: Reset when regular right-sidebar (not embodiment) is open */
+body:has(#right-container.open #right-sidebar:not(.hidden)) .debug-switcher-message:not(.hidden) {
+  transform: translateX(0);
+}
+
+/* Pure CSS: Reset when regular right-sidebar (not embodiment) is open AND no upgrade button */
+body:not(:has(#upgrade-button-topbar)):has(#right-container.open #right-sidebar:not(.hidden)) .debug-switcher-message:not(.hidden) {
+  transform: translateX(0);
+}

--- a/packages/app/views/pages/partials/studio/embodiments-new.ejs
+++ b/packages/app/views/pages/partials/studio/embodiments-new.ejs
@@ -15,7 +15,7 @@
     <span class="mif-bug icon [.active_&]:text-white w-4"></span>
     <span class="debug-switcher-text">Debug Off</span>
   </button>
-  <div class="absolute left-0 top-12 hidden debug-switcher-message">
+  <div class="absolute left-0 top-12 hidden debug-switcher-message transition-transform duration-300 ease-in-out">
     <p class="text-xs text-gray-700 bg-white rounded-md p-2 border px-2.5">
       Debug session active. Use the controls above to step through execution.
     </p>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved the positioning of debug messages to adapt dynamically when sidebars or the upgrade button are present.
  * Added smooth transition effects to debug message containers for a more polished user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->