### PR TITLE
Fix: 86eue55zr : Inspect: Auto-pop up behavior

### DIFF
--- a/packages/app/src/builder-ui/debugger.ts
+++ b/packages/app/src/builder-ui/debugger.ts
@@ -2549,20 +2549,6 @@ export function createDebugInjectDialog(
     if (userEmail) {
       const debugSessionKey = `first-debug-session-${userEmail}`;
 
-      // Compatibility: migrate any existing team/agent-scoped keys to the new user-level key
-      // Old formats included team and/or agent: first-debug-session-${userEmail}-${teamId}[-${agentId}]
-      try {
-        const legacyPrefix = `first-debug-session-${userEmail}-`;
-        for (let i = 0; i < localStorage.length; i++) {
-          const key = localStorage.key(i);
-          if (key && key.startsWith(legacyPrefix)) {
-            localStorage.setItem(debugSessionKey, 'false');
-            break;
-          }
-        }
-      } catch (_) {
-        // do nothing
-      }
 
       const isFirstDebugSession = localStorage.getItem(debugSessionKey) === null;
 


### PR DESCRIPTION
## 🎯 What’s this PR about?

This change makes the inspect/debug bar auto-pop behavior global per user rather than per agent. Once a user dismisses it on any agent, it won’t auto-pop for any agents or teams for that user. It switches the localStorage key to a user-level key and includes a compatibility check that sets the new key if any legacy team/agent-scoped keys are found.
---

## 📎 Related ClickUp Ticket

 https://app.clickup.com/t/86eue55zr

---

## 💻 Demo (optional)

https://sharing.clickup.com/clip/p/t8591381/b452fd55-4a2b-47bf-87ca-479353cff5d2/b452fd55-4a2b-47bf-87ca-479353cff5d2.webm?filename=screen-recording-2025-08-08-14%3A16.webm
---

## ✅ Checklist

- [✅] Self-reviewed the code
- [✅] Linked the correct ClickUp ticket
- [✅] Tested locally (MANDATORY)
- [ ] Marked as **Draft** if not ready for review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the handling of the first debug session indicator, making it consistent across all teams and agents for each user.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->