### PR TITLE
Fix: 86eudzg3x :  Note Component - Custom Resize Lost After Edit Operations

### DIFF
--- a/packages/app/src/builder-ui/components/Note.class.ts
+++ b/packages/app/src/builder-ui/components/Note.class.ts
@@ -162,31 +162,7 @@ export class Note extends Component {
     const markdownElement = this.domElement?.querySelector('.note-markdown');
     if (markdownElement) {
       markdownElement.remove();
-      this.autoResizeNote();
     }
-  }
-
-  private autoResizeNote(): void {
-    const contentWrapper = this.domElement?.querySelector('.note-content-wrapper');
-    if (!contentWrapper) return;
-
-    setTimeout(() => {
-      // Get the natural height of the content
-      const scrollHeight = contentWrapper.scrollHeight;
-      const titleBarHeight = 40;
-      const padding = 20;
-      const minHeight = 80;
-
-      // Calculate new height based on content
-      const calculatedHeight = scrollHeight + titleBarHeight + padding;
-      const newHeight = Math.max(calculatedHeight, minHeight);
-
-      // Resize to fit content (both shrink and grow)
-      const heightPx = newHeight + 'px';
-      this.domElement.style.height = heightPx;
-      this.properties.height = heightPx;
-      this.data._noteHeight = heightPx;
-    }, 10); // Small delay to ensure DOM is updated
   }
 
   private renderMarkdownContent(): void {
@@ -214,7 +190,6 @@ export class Note extends Component {
   private updateNoteContent(): void {
     this.domElement.querySelector('.note-text').innerHTML = this.data.description || '';
     this.renderMarkdownContent();
-    this.autoResizeNote();
   }
 
   private updateNoteStyles(): void {


### PR DESCRIPTION
## 🎯 What’s this PR about?

Previously, the autoResizeNote logic calculated the actual height of the note’s description and markdown content, then automatically resized the component to fit. While this ensured the content was fully visible, it also caused a major usability issue — any manually adjusted/custom height set by the user was overridden after an edit operation.

This change removes autoResizeNote so the note component retains the user’s custom size, even after the content is updated. Users can still manually resize notes as desired without losing their adjustments on subsequent edits.
---

## 📎 Related ClickUp Ticket

 https://app.clickup.com/t/86eudzg3x

---

## 💻 Demo (optional)

https://sharing.clickup.com/clip/p/t8591381/df04c2e2-d54a-4c76-980c-161cbb383e8a/df04c2e2-d54a-4c76-980c-161cbb383e8a.webm?filename=screen-recording-2025-08-08-14%3A35.webm
---

## ✅ Checklist

- [✅] Self-reviewed the code
- [✅] Linked the correct ClickUp ticket
- [✅] Tested locally (MANDATORY)
- [ ] Marked as **Draft** if not ready for review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Removed automatic resizing of notes based on content changes. Notes will no longer adjust their height automatically when content is updated or markdown is removed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->