### PR TITLE
Fix: 86eubqg7x : Builder/Agent Version Restore Modal - Redundant Cancel Button

### DIFF
--- a/packages/app/src/builder-ui/ui/react-injects.tsx
+++ b/packages/app/src/builder-ui/ui/react-injects.tsx
@@ -207,7 +207,6 @@ export function renderConfirmDialogModals({ rootID }: { rootID: string }) {
             message="Restore this version?"
             onClose={cancelRestore}
             handleConfirm={confirmRestore}
-            handleCancel={cancelRestore}
             lowMsg="Are you sure you want to restore this to a previous version? Any unsaved changes will be lost."
           />
         )}


### PR DESCRIPTION

## 🎯 What’s this PR about?

Remove redundant cancel button from modal as close icon is already present in the modal to stay consistent with other modals
---

## 📎 Related ClickUp Ticket

https://app.clickup.com/t/86eubqg7x

---

## 💻 Demo (optional)

https://sharing.clickup.com/clip/p/t8591381/f1cb0c6d-eaf5-4fee-b190-84a3e568e648/f1cb0c6d-eaf5-4fee-b190-84a3e568e648.webm?filename=screen-recording-2025-08-01-16%3A47.webm
---

## ✅ Checklist

- [✅] Self-reviewed the code
- [✅] Linked the correct ClickUp ticket
- [✅] Tested locally (MANDATORY)
- [ ] Marked as **Draft** if not ready for review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated the way modal actions are handled in the restore confirmation dialog for improved clarity and consistency. No changes to user-facing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->