### PR TITLE
Fix: 86eud3vqe : Agent Settings - Behavior Field Modal 'Done' Button Does Not Save Edits

### DIFF
--- a/packages/app/src/react/features/agent-settings/components/SettingsWidget.tsx
+++ b/packages/app/src/react/features/agent-settings/components/SettingsWidget.tsx
@@ -26,6 +26,7 @@ const SettingsWidget = () => {
     models: MODELS_V2,
     modal: { isOpen: isModalOpen, setIsOpen: setIsModalOpen, handleClose: handleModalClose },
     postHogEvent: { setPostHogEvent },
+    isSaving,
   } = useWidgetsContext();
 
   if (isLoading.embodiments || isLoading.llmModels) return <ComponentSkeleton />;
@@ -159,11 +160,17 @@ const SettingsWidget = () => {
             <Modal.Footer className="pt-0">
               <div className="w-full flex justify-end">
                 <Button
-                  handleClick={handleModalClose}
+                  handleClick={async () => {
+                    await formik.submitForm();
+                    handleModalClose();
+                  }}
                   type="button"
                   className="h-[48px] px-8 rounded-lg ml-auto"
+                  loading={isSaving}
+                  loaderColor="blue"
+                  disabled={isSaving}
                 >
-                  Done
+                  {isSaving ? 'Saving' : 'Done'}
                 </Button>
               </div>
             </Modal.Footer>

--- a/packages/app/src/react/shared/components/ui/newDesign/button.tsx
+++ b/packages/app/src/react/shared/components/ui/newDesign/button.tsx
@@ -35,6 +35,7 @@ interface CustomButtonProps {
   variant?: 'primary' | 'secondary' | 'tertiary' | 'quaternary';
   isDelete?: boolean;
   iconPosition?: 'left' | 'right';
+  loaderColor?: 'blue' | 'gray';
 }
 
 export function Button({
@@ -60,6 +61,7 @@ export function Button({
   btnRef,
   variant = 'primary',
   iconPosition = 'left',
+  loaderColor,
 }: CustomButtonProps) {
   const baseStyles =
     'flex items-center justify-center text-sm font-normal border border-solid text-base px-4 py-2 text-center rounded-md transition-all duration-200 outline-none focus:outline-none focus:ring-0 focus:ring-offset-0 focus:ring-shadow-none';
@@ -114,9 +116,12 @@ export function Button({
           {loading && (
             <div
               id="loader"
-              className={`mr-2 ${
-                variant === 'secondary' ? 'circular-loader-blue' : 'circular-loader'
-              }`}
+              className={`mr-2 ${(() => {
+                if (loaderColor)
+                  return loaderColor === 'blue' ? 'circular-loader-blue' : 'circular-loader';
+                // Fallback to previous behavior when not explicitly specified
+                return variant === 'secondary' ? 'circular-loader-blue' : 'circular-loader';
+              })()}`}
             ></div>
           )}
           {iconPosition === 'left' && iconElement}


### PR DESCRIPTION



## 🎯 What’s this PR about?

Users can now save their changes directly when clicking ‘Done’ in the modal, eliminating the need to click the Save button again on the Agent Settings page.
---

## 📎 Related ClickUp Ticket

 https://app.clickup.com/t/86eud3vqe

---

## 💻 Demo (optional)

https://sharing.clickup.com/clip/p/t8591381/2161ec05-fe99-48c9-a521-cd8a93945243/2161ec05-fe99-48c9-a521-cd8a93945243.webm?filename=screen-recording-2025-08-08-18%3A19.webm
---

## ✅ Checklist

- [✅] Self-reviewed the code
- [✅] Linked the correct ClickUp ticket
- [✅] Tested locally (MANDATORY)
- [ ] Marked as **Draft** if not ready for review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The "Done" button in the settings modal now displays a loading spinner and updates its label to "Saving" while changes are being saved.
  * The button is disabled during the saving process to prevent duplicate submissions.

* **Style**
  * The loading spinner on buttons can now appear in blue or gray, improving visual feedback during loading actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->