### PR TITLE
fix(agent-settings): send valid agent ID when fetching settings

### DIFF
--- a/packages/app/src/react/features/agent-settings/contexts/agent-settings.context.tsx
+++ b/packages/app/src/react/features/agent-settings/contexts/agent-settings.context.tsx
@@ -88,12 +88,19 @@ export const AgentSettingsProvider: FC<AgentSettingsProviderProps> = ({
   const [workSpaceObj, setWorkSpaceObj] = useState<Workspace | null>(workspace || null);
   const [agentAuthData, setAgentAuthData] = useState<any>(null);
 
-  let agentId = workspaceAgentId;
-  if (!agentId) {
-    // so useParams are not used unless needed
-    const params = useParams<{ agentId: string }>();
-    agentId = params.agentId;
+  // Always call useParams to avoid violating Rules of Hooks
+  const params = useParams<{ agentId: string }>();
+
+  // Fallback: extract agentId from URL if useParams fails
+  let extractedAgentId = params.agentId;
+  if (!extractedAgentId) {
+    const pathname = window.location.pathname;
+    const match = pathname.match(/\/agent-settings\/([^\/]+)/);
+    extractedAgentId = match ? match[1] : undefined;
   }
+
+  // Use workspaceAgentId if provided, otherwise use extracted agentId
+  const agentId = workspaceAgentId || extractedAgentId;
 
   function updateWorkSpaceObj() {
     setWorkSpaceObj(window['workspace']);


### PR DESCRIPTION
## 🎯 What’s this PR about?

Previously, the Agent Settings page sent an undefined ID in the request to retrieve agent settings from the backend. This caused unnecessary backend calls and potential errors. The logic has been updated to ensure a valid agent ID is always provided before making the request.
---

## 📎 Related ClickUp Ticket

<!-- Paste the link to the related ClickUp task -->
> Example: https://app.clickup.com/t/TEAM-123

---

## 💻 Demo (optional)

<!-- Link to deployed preview, video demo, or screenshots -->

---

## ✅ Checklist

- [ ] Self-reviewed the code
- [ ] Linked the correct ClickUp ticket
- [ ] Tested locally (MANDATORY)
- [ ] Marked as **Draft** if not ready for review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability in detecting the agent ID within agent settings, ensuring correct behavior even when route parameters are missing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->