### PR TITLE
Role not found when inviting from space

### DIFF
--- a/packages/app/src/react/features/agents/contexts/OnboardingContext.tsx
+++ b/packages/app/src/react/features/agents/contexts/OnboardingContext.tsx
@@ -28,6 +28,9 @@ type OnboardingContextType = {
 
   isInviteMemberModalOpen: boolean;
   setInviteMemberModalOpen: (isInviteMemberModalOpen: boolean) => void;
+
+  isAssignMemberModalOpen: boolean;
+  setAssignMemberModalOpen: (isAssignMemberModalOpen: boolean) => void;
 };
 
 const OnboardingContext = createContext<OnboardingContextType | undefined>(undefined);
@@ -50,6 +53,7 @@ export const OnboardingProvider: FC<{ children: ReactNode }> = ({ children }) =>
   const [isOnboardingDismissed, setOnboardingDismissed] = useState(false);
   const [isOnboardingFinished, setIsOnboardingFinished] = useState(false);
   const [isInviteMemberModalOpen, setInviteMemberModalOpen] = useState(false);
+  const [isAssignMemberModalOpen, setAssignMemberModalOpen] = useState(false);
 
   const setTasksWrapper = (tasks: OnboardingTaskProps[]) => {
     setTasks(tasks);
@@ -149,6 +153,8 @@ export const OnboardingProvider: FC<{ children: ReactNode }> = ({ children }) =>
         setOnboardingDismissed,
         isInviteMemberModalOpen,
         setInviteMemberModalOpen,
+        isAssignMemberModalOpen,
+        setAssignMemberModalOpen,
       }}
     >
       {children}

--- a/packages/app/src/react/features/onboarding/components/agent-onboarding-section/OnboardingTask.tsx
+++ b/packages/app/src/react/features/onboarding/components/agent-onboarding-section/OnboardingTask.tsx
@@ -1,6 +1,7 @@
 import { UserSettingsKey } from '@src/backend/types/user-data';
 import { useOnboarding } from '@src/react/features/agents/contexts/OnboardingContext';
 import useMutateOnboardingData from '@src/react/features/onboarding/hooks/useMutateOnboardingData';
+import { useAuthCtx } from '@src/react/shared/contexts/auth.context';
 import { OnboardingTaskProps, OnboardingTaskType } from '@src/react/shared/types/onboard.types';
 import { Analytics } from '@src/shared/posthog/services/analytics';
 import classNames from 'classnames';
@@ -63,7 +64,8 @@ const OnboardingTask = ({
   icon,
 }: OnboardingTaskProps) => {
   const saveUserSettingsMutation = useMutateOnboardingData();
-  const { setTaskCompleted, setInviteMemberModalOpen } = useOnboarding();
+  const { setTaskCompleted, setInviteMemberModalOpen, setAssignMemberModalOpen } = useOnboarding();
+  const { currentUserTeam } = useAuthCtx();
 
   const completeTask = (button) => {
     const effectiveType = button.type || type;
@@ -84,7 +86,15 @@ const OnboardingTask = ({
 
   const handleInviteTeamMembers = (e: React.MouseEvent<HTMLDivElement>) => {
     e.preventDefault();
-    setInviteMemberModalOpen(true);
+
+    // Check if current team is organization (parentId === null) or space (parentId !== null)
+    const isOrganization = currentUserTeam?.parentId === null;
+
+    if (isOrganization) {
+      setInviteMemberModalOpen(true);
+    } else {
+      setAssignMemberModalOpen(true);
+    }
   };
 
   if (type === OnboardingTaskType.INVITE_TEAM_MEMBERS) {


### PR DESCRIPTION


## 🎯 What’s this PR about?

<!-- Brief summary of what this PR does -->
When on dashboard in Space we try to invite member from Invite member button inside Onboarding tasks. It was showing invite member screen meant for the organization. Show correct modal that handles add member for Space

---

## 📎 Related ClickUp Ticket
https://app.clickup.com/t/86eu8hygv

---

## 💻 Demo (optional)
https://sharing.clickup.com/clip/p/t8591381/31959640-5bc9-4cc0-af68-e44f68d42206/31959640-5bc9-4cc0-af68-e44f68d42206.webm?filename=screen-recording-2025-08-08-18%3A46.webm
<!-- Link to deployed preview, video demo, or screenshots -->

---

## ✅ Checklist

- [ ] Self-reviewed the code
- [ ] Linked the correct ClickUp ticket
- [ ] Tested locally (MANDATORY)
- [ ] Marked as **Draft** if not ready for review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced an assign member modal in the onboarding tasks, allowing users to assign members based on their team type.
  * The onboarding flow now dynamically fetches and displays organization members when assigning members.
* **Enhancements**
  * Onboarding tasks adapt modal behavior depending on whether the user belongs to an organization or a sub-team.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->