### PR TITLE
tracking tutorial complete event

### DIFF
--- a/packages/app/src/react/features/agents/hooks/useAgentsPageTutorial.ts
+++ b/packages/app/src/react/features/agents/hooks/useAgentsPageTutorial.ts
@@ -1,4 +1,5 @@
 import { useAuthCtx } from '@react/shared/contexts/auth.context';
+import { Analytics } from '@src/shared/posthog/services/analytics';
 import { useEffect } from 'react';
 
 type UseAgentsPageTutorialOptions = {
@@ -52,6 +53,13 @@ export function useAgentsPageTutorial(options: UseAgentsPageTutorialOptions = {}
             setTimeout(() => {
               popoverElements.popoverTitle.innerText = `${popoverElements.popoverTitle.innerText} (${home_page_onboarding.currentStep + 1}/${home_page_onboarding.getSteps().length})`;
             }, 0);
+          },
+          onReset: () => {
+            // Called when overlay is about to be cleared
+            Analytics.track('home_page_tutorial_completed', {
+              page_url: '/agents',
+              source: 'Tutorial completed on home page onboarding'
+            });
           },
           animate: true,
           showButtons: true,

--- a/packages/app/src/shared/posthog/services/analytics.ts
+++ b/packages/app/src/shared/posthog/services/analytics.ts
@@ -1,10 +1,19 @@
 import { PostHog } from '@src/shared/posthog';
+import { isProdEnv } from '@src/shared/utils';
 
 export const Analytics = {
-  track: (eventName: string, properties: {} = {}) => {
+  track: (eventName: string, properties: Record<string, any> = {}) => {
     try {
       // so any error doesn't break the app
-      PostHog.track(eventName, properties);
+      const enhancedProperties = { ...properties };
+      
+      // Add isProd if not already present to differentiate between prod and dev events
+      if (!('isProd' in enhancedProperties)) {
+        enhancedProperties.isProd = isProdEnv();
+      }
+      
+      PostHog.track(eventName, enhancedProperties);
+      
     } catch (error) {
       console.info('Error tracking event', error);
     }


### PR DESCRIPTION
## 🎯 What’s this PR about?
Track tutorial complete event
<!-- Brief summary of what this PR does -->
1. When tutorial has completed on clicking done it  triggers reset event. on this event we tracking tutorial complete event.
2. also send isProd key for all events because we are not disabling tracking for dev. this key will help filter out development environment noise
---

## 📎 Related ClickUp Ticket
https://app.clickup.com/t/86eud32xf
<!-- Paste the link to the related ClickUp task -->
> Example: https://app.clickup.com/t/TEAM-123

---

## 💻 Demo (optional)
<img width="1624" height="780" alt="image" src="https://github.com/user-attachments/assets/47d2a657-1194-4286-b8e5-8515b0b3c49d" />

<!-- Link to deployed preview, video demo, or screenshots -->

---

## ✅ Checklist

- [ ] Self-reviewed the code
- [ ] Linked the correct ClickUp ticket
- [ ] Tested locally (MANDATORY)
- [ ] Marked as **Draft** if not ready for review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * Tracking added when the Agents page tutorial is completed.

* Chores
  * Analytics events now automatically include environment context for clearer event attribution.
  * Improved event property handling for consistency across tracked actions.

* Notes
  * No UI changes; behavior is unchanged for end-users aside from improved telemetry on tutorial completion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->