### PR TITLE
refactor hotkey confirmation labels for clarity

### DIFF
--- a/packages/app/src/builder-ui/workspace/hotkeys.ts
+++ b/packages/app/src/builder-ui/workspace/hotkeys.ts
@@ -27,7 +27,7 @@ export function registerHotkeys(workspace: Workspace) {
   const hotkey: any = hotkeys.noConflict();
   const deleteHotkeys = 'del, backspace';
   let deleteConfirmationActive = false; // Flag to prevent multiple modals
-  
+
   // Initialize search functionality
   const searchHelper = CanvasSearchHelper.getInstance();
   try {
@@ -91,8 +91,8 @@ export function registerHotkeys(workspace: Workspace) {
       `Are you sure you want to delete selected ${confirmText}?`,
       {
         icon: '',
-        btnNoLabel: 'No, Cancel',
-        btnYesLabel: "Yes, I'm sure",
+        btnNoLabel: 'Cancel',
+        btnYesLabel: `Delete ${confirmText}`,
         btnYesClass: 'bg-smyth-red-500 border-smyth-red-500',
       },
     );


### PR DESCRIPTION
## 🎯 What’s this PR about?

<!-- Brief summary of what this PR does -->

---

## 📎 Related ClickUp Ticket

<!-- Paste the link to the related ClickUp task -->
> ClickUp: https://app.clickup.com/t/86eufmd4n

---

## 💻 Demo (optional)

<!-- Link to deployed preview, video demo, or screenshots -->

---

## ✅ Checklist

- [x] Self-reviewed the code
- [x] Linked the correct ClickUp ticket
- [x] Tested locally (MANDATORY)
- [ ] Marked as **Draft** if not ready for review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Style
  - Updated delete confirmation dialog for clearer actions: buttons now read “Cancel” and “Delete {confirmText},” dynamically reflecting the item name and singular/plural context.
  - The confirmation prompt remains: “Are you sure you want to delete selected {confirmText}?”
  - Minor whitespace cleanup with no functional impact.
  - No changes to user workflows or shortcuts; behavior remains the same aside from improved button labeling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->