### PR TITLE
Builder Canvas - Save Indicator Cloud Icon Obscured by Expanded Sidebar

### DIFF
--- a/packages/app/views/pages/partials/studio/agent-status.ejs
+++ b/packages/app/views/pages/partials/studio/agent-status.ejs
@@ -1,4 +1,12 @@
-<div class="flex flex-col" id="agent-status">
+<div
+  x-data="sidebarState()"
+  class="flex flex-col absolute top-[34px]"
+  id="agent-status"
+  :class="{
+    '-right-[60px]': isSidebarOpen,
+    '-right-[44px]': !isSidebarOpen
+  }"
+>
   <div class="flex">
     <div id="agent-top-bar-status">
       <div class="text-xs flex gap-1 items-center h-full">

--- a/packages/app/views/pages/partials/studio/builder-menu.ejs
+++ b/packages/app/views/pages/partials/studio/builder-menu.ejs
@@ -29,7 +29,6 @@
         <% if (typeof agent !== 'undefined' && agent) { %> <%= agent.name %> <% } %>
       </p>
     </div>
-    <%- include('agent-status'); -%>
   </div>
 
   <!-- Right side: Search, New Agent, Agent Chat, and User Menu -->

--- a/packages/app/views/pages/partials/studio/left-sidebar.ejs
+++ b/packages/app/views/pages/partials/studio/left-sidebar.ejs
@@ -825,6 +825,8 @@
       <span class="text-gray-300"> Click</span>
     </div>
   </div>
+
+  <%- include('agent-status'); -%>
 </div>
 
 <script>


### PR DESCRIPTION
## 🎯 What’s this PR about?

<!-- Brief summary of what this PR does -->

--- Cloud icon change it's position w.r.t left sidebar

## 📎 Related ClickUp Ticket

<!-- Paste the link to the related ClickUp task -->

--- https://app.clickup.com/t/86eudp98u

## 💻 Demo (optional)

<!-- Link to deployed preview, video demo, or screenshots -->

--- https://sharing.clickup.com/clip/p/t8591381/bb3586e7-eb21-41cf-abbd-f584d30e6488/bb3586e7-eb21-41cf-abbd-f584d30e6488.webm?filename=screen-recording-2025-08-14-21%3A28.webm

## ✅ Checklist

- [x] Self-reviewed the code
- [x] Linked the correct ClickUp ticket
- [x] Tested locally (MANDATORY)
- [ ] Marked as **Draft** if not ready for review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Moved Agent Status from the top bar to the left sidebar as an overlay, improving contextual placement without changing functionality.
  * Overlay now dynamically shifts horizontally based on sidebar open/closed state.

* **Style**
  * Updated positioning and spacing of the Agent Status overlay (offset from top) to align with the sidebar layout and maintain visual consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->