### PR TITLE
Builder/Help Sidebar - Missing Scroll Indicator Hides Keyboard Shortcuts Option

### DIFF
--- a/packages/app/views/pages/partials/studio/left-sidebar-help.ejs
+++ b/packages/app/views/pages/partials/studio/left-sidebar-help.ejs
@@ -22,7 +22,7 @@
     <div>
       <button
         type="button"
-        class="close-btn size-10 p-0.5 rounded-full text-[#757575]"
+        class="close-btn p-0.5 rounded-full text-[#757575]"
         data-tooltip-target="tooltip-close-help"
         data-tooltip-placement="left"
         @click="


### PR DESCRIPTION
## 🎯 What’s this PR about?

<!-- Brief summary of what this PR does -->

--- Enable scrollbar for help sidebar

## 📎 Related ClickUp Ticket

<!-- Paste the link to the related ClickUp task -->

--- https://app.clickup.com/t/86eudpdy7

## 💻 Demo (optional)

<!-- Link to deployed preview, video demo, or screenshots -->

--- https://sharing.clickup.com/clip/p/t8591381/629f25db-2634-4e39-ab7a-c46b1ea521ee/629f25db-2634-4e39-ab7a-c46b1ea521ee.webm?filename=screen-recording-2025-08-14-21%3A51.webm

## ✅ Checklist

- [ ] Self-reviewed the code
- [ ] Linked the correct ClickUp ticket
- [ ] Tested locally (MANDATORY)
- [ ] Marked as **Draft** if not ready for review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Refined spacing in the Left Sidebar Help panel by moving horizontal padding to the inner content for better alignment and consistency.
  - Adjusted close button sizing for a cleaner, more consistent appearance.
  - Restored default scrollbar visibility in the Help panel content to improve discoverability and accessibility.
  - Simplified outer container padding, reducing unnecessary horizontal padding while maintaining vertical spacing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->