### PR TITLE
use doNotValidateOnLoad to offset validation for component field on creations

### DIFF
--- a/packages/app/src/builder-ui/components/APIEndpoint.class.ts
+++ b/packages/app/src/builder-ui/components/APIEndpoint.class.ts
@@ -53,6 +53,7 @@ export class APIEndpoint extends Component {
       endpoint: {
         type: 'input',
         label: 'Skill Name',
+        doNotValidateOnLoad: true,
         value: '',
         validate: `required maxlength=50 custom=isValidEndpoint`,
         validateMessage: `Provide a valid endpoint that only contains 'a-z', 'A-Z', '0-9', '-', '_' , without leading or trailing spaces. Length should be less than 50 characters.`,

--- a/packages/app/src/builder-ui/ui/form/createFormField.ts
+++ b/packages/app/src/builder-ui/ui/form/createFormField.ts
@@ -367,7 +367,25 @@ export default function createFormField(entry, displayType = 'block', entryIndex
   //formElement.setAttribute('data-prepend', entry.label || entry.name); //
 
   if (entry.readonly) formElement.setAttribute('readonly', '');
-  if (entry.validate) formElement.setAttribute('data-validate', entry.validate);
+  if (entry.validate) {
+    if (entry.doNotValidateOnLoad) {
+      // Store validation rules but don't apply them yet
+      formElement.setAttribute('data-validate-rules', entry.validate);
+      // Add validation after first user interaction
+      const enableValidation = () => {
+        formElement.setAttribute('data-validate', entry.validate);
+        formElement.removeAttribute('data-validate-rules');
+        formElement.removeEventListener('focus', enableValidation);
+        formElement.removeEventListener('input', enableValidation);
+        formElement.removeEventListener('change', enableValidation);
+      };
+      formElement.addEventListener('focus', enableValidation, { once: true });
+      formElement.addEventListener('input', enableValidation, { once: true });
+      formElement.addEventListener('change', enableValidation, { once: true });
+    } else {
+      formElement.setAttribute('data-validate', entry.validate);
+    }
+  }
 
   /*
     * "entry.smythValidate" allows custom validation using asynchronous functions. (Metro UI does not support asynchronous function.)

--- a/packages/app/src/builder-ui/utils/form.utils.ts
+++ b/packages/app/src/builder-ui/utils/form.utils.ts
@@ -1,4 +1,3 @@
-import { delay } from './general.utils';
 
 export const focusField = (elm: HTMLInputElement) => {
   if (!elm) return;

--- a/packages/app/static/css/smyth-metro-override.css
+++ b/packages/app/static/css/smyth-metro-override.css
@@ -52,6 +52,11 @@
   padding: 0 !important;
 }
 
+.input.invalid:focus,
+.input.invalid.focused {
+  -webkit-box-shadow: none !important;
+  box-shadow: none !important;
+}
 /* Remove checkerboard pattern from external Coloris library */
 /* High specificity overrides for CDN Coloris CSS */
 


### PR DESCRIPTION

## 🎯 What’s this PR about?
Do not run validation on skill name as soon its created. it gives the impression that we have created a broken component
<!-- Brief summary of what this PR does -->

---

## 📎 Related ClickUp Ticket
https://app.clickup.com/t/86eugc1dv
<!-- Paste the link to the related ClickUp task -->
> Example: https://app.clickup.com/t/TEAM-123

---

## 💻 Demo (optional)
https://sharing.clickup.com/clip/p/t8591381/d1543f55-a1db-4853-b47c-442b24f9e2d0/d1543f55-a1db-4853-b47c-442b24f9e2d0.webm?filename=screen-recording-2025-08-18-17%3A50.webm
<!-- Link to deployed preview, video demo, or screenshots -->

---

## ✅ Checklist

- [ ] Self-reviewed the code
- [ ] Linked the correct ClickUp ticket
- [ ] Tested locally (MANDATORY)
- [ ] Marked as **Draft** if not ready for review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * Introduced deferred validation for form fields, preventing validation from running on page load. Initially applied to the “Skill Name” field; validation now triggers on first user interaction.

* Style
  * Updated invalid input focus styling to remove the focus glow, improving visual clarity when fields are in an error state.

* Chores
  * Removed an unused utility import with no impact on functionality or public APIs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->