### PR TITLE
Fix: Expanding "advanced" section removes test button

### DIFF
--- a/packages/app/src/builder-ui/ui/form/form.ts
+++ b/packages/app/src/builder-ui/ui/form/form.ts
@@ -240,16 +240,6 @@ export function createForm(entriesObject, displayType = 'block'): FormHTMLElemen
         arrow.style.transform = 'translateX(10px)';
       }
     });
-
-    // Add click handler to Advanced section toggle to show/hide test API button
-    const advancedToggle = form.querySelector('#collapse_toggle_Advanced') as HTMLElement;
-    advancedToggle?.addEventListener('click', () => {
-      if (!advancedToggle.classList.contains('active-toggle')) {
-        testApiButton.classList.add('hidden');
-      } else {
-        testApiButton.classList.remove('hidden');
-      }
-    });
     form.appendChild(testApiButton);
   }
 


### PR DESCRIPTION
## 🎯 What’s this PR about?
Remove the functionality where opening advanced option inside skill settings would hide test api button.
<!-- Brief summary of what this PR does -->

---

## 📎 Related ClickUp Ticket
https://app.clickup.com/t/86eum1jbt

---

## 💻 Demo (optional)
https://sharing.clickup.com/clip/p/t8591381/248401ac-9572-4696-a3c5-ad3035146b97/248401ac-9572-4696-a3c5-ad3035146b97.webm?filename=screen-recording-2025-08-25-16%3A32.webm
<!-- Link to deployed preview, video demo, or screenshots -->

---

## ✅ Checklist

- [ ] Self-reviewed the code
- [ ] Linked the correct ClickUp ticket
- [ ] Tested locally (MANDATORY)
- [ ] Marked as **Draft** if not ready for review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * The Test API Endpoint button is now always visible, independent of the Advanced toggle. Users no longer need to expand Advanced to access it.
  * Existing click and hover behavior for the button remains unchanged.

* **Chores**
  * No changes to public APIs or exported interfaces.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->