### PR TITLE
Fix: 86eufmcrg: Refactor Note to use unified content and formatting mode

### DIFF
--- a/packages/app/src/builder-ui/components/Note.class.ts
+++ b/packages/app/src/builder-ui/components/Note.class.ts
@@ -13,13 +13,52 @@ export class Note extends Component {
       typographer: true, // Smart quotes, dashes, etc.
     });
 
+    // --- MIGRATION LOGIC FOR OLD NOTES ---
+    // If old fields exist, migrate to new model
+    if (typeof this.data.formatting_mode === 'undefined') {
+      let desc = this.data.description || '';
+      let md = this.data.markdown_content || '';
+
+      if (this.data.markdown_enabled) {
+        this.data.formatting_mode = 'markdown';
+        this.data.content = (desc && md) ? (desc.trim() + '\n\n' + md.trim()) : (md || desc);
+      } else {
+        this.data.formatting_mode = 'plaintext';
+        this.data.content = desc || '';
+      }
+    }
+    // Ensure content is always present
+    if (typeof this.data.content === 'undefined') this.data.content = '';
+    // Fallback to preserve old description if content is empty
+    if (!this.data.content && this.data.description) {
+      this.data.content = this.data.description;
+    }
     // #region [ Settings config ] ==================
     this.settings = {
-      description: {
+      formatting_mode: {
+        type: 'dropdown',
+        label: 'Formatting Mode',
+        value: this.data.formatting_mode || 'plaintext',
+        options: [
+          { text: 'Plain Text', value: 'plaintext' },
+          { text: 'Markdown', value: 'markdown' },
+        ],
+        help: 'Choose how your note content is formatted and displayed.',
+        tooltipClasses: 'w-56 ',
+        arrowClasses: '-ml-11',
+        hintPosition: 'bottom',
+        events: {
+          change: (e) => {
+            this.data.formatting_mode = e.target.value;
+            this.updateNoteContent();
+          },
+        },
+      },
+      content: {
         type: 'textarea',
-        label: 'Description',
-        value: '',
-        help: "Add a note's text content to keep track of ideas, tasks, or reminders.",
+        label: 'Content',
+        value: this.data.content || '',
+        help: "Add your note's text or markdown content.",
         tooltipClasses: 'w-56 ',
         arrowClasses: '-ml-11',
         hintPosition: 'bottom',
@@ -31,7 +70,7 @@ export class Note extends Component {
         type: 'color',
         label: 'Text Color',
         class: 'w-full',
-        value: '#000000',
+        value: this.data.textColor || '#000000',
         help: "Choose the color of the note's text to improve readability or match your style.",
         tooltipClasses: 'w-56 ',
         arrowClasses: '-ml-11',
@@ -49,7 +88,7 @@ export class Note extends Component {
         type: 'color',
         label: 'Background Color',
         class: 'w-full',
-        value: '#c7ff1529',
+        value: this.data.color || '#c7ff1529',
         help: 'Set the background color of the note to organize or highlight different types of information.',
         tooltipClasses: 'w-56 ',
         arrowClasses: '-ml-11',
@@ -60,34 +99,9 @@ export class Note extends Component {
           },
         },
       },
-      markdown_enabled: {
-        type: 'toggle',
-        label: 'Enable Markdown',
-        section: 'Advanced',
-        value: true,
-        help: 'If enabled, allows you to add markdown content that will be rendered in the note.',
-        tooltipClasses: 'w-64 ',
-        arrowClasses: '-ml-11',
-        display: 'inline',
-        events: {
-          change: this.markdownToggleHandler.bind(this),
-        },
-      },
-      markdown_content: {
-        type: 'textarea',
-        label: 'Markdown Content',
-        section: 'Advanced',
-        value: '',
-        help: 'Add markdown content that will be rendered in the note.',
-        tooltipClasses: 'w-56 ',
-        arrowClasses: '-ml-11',
-        hintPosition: 'bottom',
-        validate: `maxlength=5000`,
-        validateMessage: 'Your text exceeds the 5,000 character limit.',
-      },
     };
 
-    const dataEntries = ['color', 'textColor', 'markdown_enabled', 'markdown_content'];
+    const dataEntries = ['color', 'textColor', 'formatting_mode', 'content'];
     for (let item of dataEntries) {
       if (typeof this.data[item] === 'undefined') this.data[item] = this.settings[item].value;
     }
@@ -166,30 +180,36 @@ export class Note extends Component {
   }
 
   private renderMarkdownContent(): void {
+    // Only render if markdown mode and content exists
+    if (this.data.formatting_mode !== 'markdown' || !this.data.content?.trim()) {
+      this.removeMarkdownContent();
+      return;
+    }
     // Clear existing markdown content
     const existingMarkdown = this.domElement?.querySelector('.note-markdown');
     if (existingMarkdown) {
       existingMarkdown.remove();
     }
-
-    // Only render if markdown is enabled and content exists
-    if (!this.data.markdown_enabled || !this.data.markdown_content?.trim()) {
-      return;
-    }
-
     const contentWrapper = this.domElement?.querySelector('.note-content-wrapper');
     if (!contentWrapper) return;
 
-    // Create and append markdown container
+    // Create and append markdown container (no separator line)
     const markdownDiv = document.createElement('div');
     markdownDiv.classList.add('note-markdown');
-    markdownDiv.innerHTML = this.markdownParser.render(this.data.markdown_content);
+    markdownDiv.innerHTML = this.markdownParser.render(this.data.content);
     contentWrapper.appendChild(markdownDiv);
   }
 
   private updateNoteContent(): void {
-    this.domElement.querySelector('.note-text').innerHTML = this.data.description || '';
-    this.renderMarkdownContent();
+    const textEl = this.domElement.querySelector('.note-text');
+    if (!textEl) return;
+    if (this.data.formatting_mode === 'markdown') {
+      textEl.innerHTML = '';
+      this.renderMarkdownContent();
+    } else {
+      this.removeMarkdownContent();
+      textEl.textContent = this.data.content || '';
+    }
   }
 
   private updateNoteStyles(): void {
@@ -211,16 +231,12 @@ export class Note extends Component {
     if (backgroundColorInput && this.data.color) {
       backgroundColorInput.style.backgroundColor = this.data.color;
     }
-
-    // Handle markdown field visibility
-    const markdownContentField = sidebar.querySelector('.form-box[data-field-name="markdown_content"]');
-    if (markdownContentField) {
-      markdownContentField.classList.toggle('hidden', !this.data.markdown_enabled);
-    }
   }
 
   protected async run(): Promise<any> {
     this.addEventListener('settingsSaved', (e) => {
+      this.data.content = this.settings.content.value;
+      this.data.formatting_mode = this.settings.formatting_mode.value;
       this.updateNoteContent();
       this.updateNoteStyles();
     });
@@ -270,19 +286,21 @@ export class Note extends Component {
     div.querySelector('.input-container').classList.add('hidden');
     div.querySelector('.output-container').classList.add('hidden');
     div.querySelector('.button-container').classList.add('hidden');
-
-    // Create a content wrapper to contain both description and markdown
+    // Create a content wrapper to contain the content
     const contentWrapper = document.createElement('div');
     contentWrapper.classList.add('note-content-wrapper');
 
     const text = document.createElement('pre');
     text.classList.add('note-text');
-    text.innerHTML = this.data.description || '';
 
+    if (this.data.formatting_mode === 'markdown') {
+      text.innerHTML = '';
+    } else {
+      text.textContent = this.data.content || '';
+    }
     contentWrapper.appendChild(text);
     div.appendChild(contentWrapper);
-
-    // Render markdown content after the description text
+    // Render markdown content after the description text (no separator line)
     setTimeout(() => {
       this.renderMarkdownContent();
     }, 0);

--- a/packages/app/static/css/smyth-components.css
+++ b/packages/app/static/css/smyth-components.css
@@ -250,7 +250,6 @@
 .Note .note-markdown {
   padding: 10px;
   margin-top: 10px;
-  border-top: 1px solid rgba(0, 0, 0, 0.15);
   overflow: auto;
   max-height: calc(100% - 120px);
   box-sizing: border-box;


### PR DESCRIPTION
## 🎯 What’s this PR about?

Migrates old note fields to a new model with a single 'content' field and a 'formatting_mode' dropdown for plaintext or markdown. Removes legacy markdown fields and toggles, updates rendering logic to use the new model, and cleans up related CSS by removing the markdown separator line.
---

## 📎 Related ClickUp Ticket

https://app.clickup.com/t/86eufmcrg

---

## 💻 Demo (optional)

<!-- Link to deployed preview, video demo, or screenshots -->

---

## ✅ Checklist

- [✅] Self-reviewed the code
- [✅] Linked the correct ClickUp ticket
- [✅] Tested locally (MANDATORY)
- [ ] Marked as **Draft** if not ready for review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a unified Note content model with a formatting mode (Plain Text or Markdown) and a single content field.
  * Automatic migration of existing Notes, preserving descriptions and markdown content.
  * Improved rendering: Markdown is only rendered when explicitly selected; otherwise content displays as plain text.

* **Bug Fixes**
  * Enhanced stability when switching formatting modes or when content is empty.

* **Style**
  * Removed the top border from the Note’s markdown section for a cleaner appearance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->