### PR TITLE
Fix: 86eucbaxa : Update Arcade iframe source URL in sidebar help

### DIFF
--- a/packages/app/views/pages/partials/studio/left-sidebar-help.ejs
+++ b/packages/app/views/pages/partials/studio/left-sidebar-help.ejs
@@ -263,7 +263,7 @@
 
         <!-- Arcade iframe -->
         <iframe
-          src="https://app.arcade.software/xAGgTWEM6EVP57670ikM"
+          src="https://demo.arcade.software/YxF1cCoJ40EbefdkvdYD?embed&embed_mobile=tab&embed_desktop=inline&show_copy_link=true"
           frameborder="0"
           loading="lazy"
           allowfullscreen


### PR DESCRIPTION


## 🎯 What’s this PR about?

Replaces the Arcade iframe src with a new demo URL and additional embed parameters to improve integration and user experience in the left sidebar help partial.
---

## 📎 Related ClickUp Ticket

https://app.clickup.com/t/86eucbaxa

---

## 💻 Demo (optional)

https://sharing.clickup.com/clip/p/t8591381/6a5afcef-fb11-4b4a-a524-029c360db122/6a5afcef-fb11-4b4a-a524-029c360db122.webm?filename=screen-recording-2025-08-26-17%3A02.webm
---

## ✅ Checklist

- [✅] Self-reviewed the code
- [✅] Linked the correct ClickUp ticket
- [✅] Tested locally (MANDATORY)
- [ ] Marked as **Draft** if not ready for review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the Help sidebar modal to use a refreshed interactive demo embed.
  * Improved viewing experience with inline desktop and tabbed mobile modes.
  * Added a copy-link option for easier sharing of the demo.
  * Ensures more reliable loading and a smoother in-app help experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->