### PR TITLE
Fix: 86eumn0bb : Builder/Note Component - Content Not Persisting After Save

### DIFF
--- a/packages/app/src/builder-ui/components/Note.class.ts
+++ b/packages/app/src/builder-ui/components/Note.class.ts
@@ -235,8 +235,8 @@ export class Note extends Component {
 
   protected async run(): Promise<any> {
     this.addEventListener('settingsSaved', (e) => {
-      this.data.content = this.settings.content.value;
-      this.data.formatting_mode = this.settings.formatting_mode.value;
+      // The data has already been updated by the general save mechanism
+      // We just need to update the UI to reflect the changes
       this.updateNoteContent();
       this.updateNoteStyles();
     });


### PR DESCRIPTION



## 🎯 What’s this PR about?

Removes redundant data updates in the settingsSaved event handler, relying on the general save mechanism to update data. The handler now only updates the UI to reflect changes.
---

## 📎 Related ClickUp Ticket

https://app.clickup.com/t/86eumn0bb

---

## 💻 Demo (optional)

https://sharing.clickup.com/clip/p/t8591381/eb614068-aa90-42e4-9b0a-54a0f8a8f0d8/eb614068-aa90-42e4-9b0a-54a0f8a8f0d8.webm?filename=screen-recording-2025-08-27-12%3A50.webm
---

## ✅ Checklist

- [✅] Self-reviewed the code
- [✅] Linked the correct ClickUp ticket
- [✅] Tested locally (MANDATORY)
- [ ] Marked as **Draft** if not ready for review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - None.

- Bug Fixes
  - Ensures note content and styling refresh correctly after saving settings, improving UI consistency.

- Refactor
  - Streamlined the note update flow after saving settings, relying on a unified save mechanism and focusing updates on UI refresh.

- Tests
  - None.

- Documentation
  - None.

- Chores
  - None.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->