### PR TITLE
fix(CanvasContextMenu): allow default context menu for debug textareas

### DIFF
--- a/packages/app/src/builder-ui/workspace/CanvasContextMenu.ts
+++ b/packages/app/src/builder-ui/workspace/CanvasContextMenu.ts
@@ -249,6 +249,15 @@ export function registerCanvasContextMenu(workspace: Workspace) {
     // Restrict to inside the workspace container
     if (!workspace.container.contains(e.target as Node)) return;
 
+    // Check if the target is inside a debug textarea
+    const target = e.target as Element;
+    const textareaElement = target.closest('.dbg-element .dbg-textarea');
+
+    // If clicking inside a debug textarea, allow default browser context menu
+    if (textareaElement) {
+      return; // Don't prevent default, let browser handle it
+    }
+
     e.preventDefault();
     e.stopPropagation();
     await createAndShowMenu(e, workspace);


### PR DESCRIPTION
## 🎯 What’s this PR about?

<!-- Brief summary of what this PR does -->

--- Builder/Canvas Output - Context Menu Overrides Text Copy (Staging)

## 📎 Related ClickUp Ticket

<!-- Paste the link to the related ClickUp task -->
> Example: https://app.clickup.com/t/TEAM-123

--- https://app.clickup.com/t/86eumy476

## 💻 Demo (optional)

<!-- Link to deployed preview, video demo, or screenshots -->

---

## ✅ Checklist

- [ ] Self-reviewed the code
- [ ] Linked the correct ClickUp ticket
- [ ] Tested locally (MANDATORY)
- [ ] Marked as **Draft** if not ready for review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Right-clicking inside debug textareas now shows the browser’s native context menu instead of the custom one.
  * Prevents unintended interception of right-click actions in debug inputs, improving text editing and copy/paste workflows.
  * Behavior for right-clicks elsewhere in the workspace remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->