### PR TITLE
remove  redraw as large names are now handled by css

### DIFF
--- a/packages/app/src/builder-ui/components/AgentCard.class.ts
+++ b/packages/app/src/builder-ui/components/AgentCard.class.ts
@@ -167,37 +167,6 @@ export class AgentCard extends EventEmitter {
   }
 
   /**
-   * Refresh skill connections for the agent card
-   * This method updates only the connections between the agent card and skills
-   * without redrawing the entire card - useful when agent properties change
-   */
-  public async repaintSkillConnections(): Promise<void> {
-    if (!this.workspace.agent?.data?.components) return;
-
-    // Get skills once to avoid duplicate filtering
-    const skills = this.workspace.agent.data.components.filter((c) => c.name === 'APIEndpoint');
-    if (skills.length === 0) return;
-
-    // Handle connections for all skills
-    for (const skill of skills) {
-      await this.handleCompConn(skill.id);
-    }
-
-    // Single repaint operation for all affected elements
-    // This is more efficient than multiple individual repaints
-    const elementsToRepaint = [
-      this.domElement, // Agent card
-      ...skills.map((skill) => document.querySelector(`#${skill.id}`)).filter(Boolean),
-    ];
-
-    elementsToRepaint.forEach((element) => {
-      if (element) {
-        this.workspace.jsPlumbInstance.repaint(element);
-      }
-    });
-  }
-
-  /**
    * Redraw the agent card
    */
   public async redraw(): Promise<void> {
@@ -675,10 +644,9 @@ export class AgentCard extends EventEmitter {
       e.stopPropagation();
     });
 
-    this.workspace.addEventListener('AgentSaved', async () => {
+    this.workspace.addEventListener('AgentSaved', () => {
       if (agentNameElement && this.workspace.agent?.data?.name != agentNameElement.textContent) {
         agentNameElement.textContent = this.workspace.agent?.data?.name || '';
-        await this.repaintSkillConnections();
       }
 
       // const topBarAgentAvatarElm: HTMLImageElement | null = document.querySelector('#agent-avatar');


### PR DESCRIPTION
## 🎯 What’s this PR about?
remove  redraw as large names are now handled by css
<!-- Brief summary of what this PR does -->

---

## 📎 Related ClickUp Ticket
https://app.clickup.com/t/86eudrk1b

Related PR: https://github.com/SmythOS/smyth-ui-enterprise/pull/23
<!-- Paste the link to the related ClickUp task -->
> Example: https://app.clickup.com/t/TEAM-123

---

## 💻 Demo (optional)

<!-- Link to deployed preview, video demo, or screenshots -->

---

## ✅ Checklist

- [ ] Self-reviewed the code
- [ ] Linked the correct ClickUp ticket
- [ ] Tested locally (MANDATORY)
- [ ] Marked as **Draft** if not ready for review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Streamlined agent save handling to avoid unnecessary recalculation of skill connections, improving responsiveness.

- **Bug Fixes**
  - Eliminated redundant refresh of skill connections after saving an agent, reducing UI flicker and unintended visual updates.

- **Chores**
  - Removed unused internal method related to redrawing skill connections to simplify the codebase and reduce maintenance overhead.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->