### PR TITLE
Fix: 86eudbn83 : Agent Skill Component - Default Values Not Visible in Compact Mode

### DIFF
--- a/packages/app/src/builder-ui/components/APIEndpoint.class.ts
+++ b/packages/app/src/builder-ui/components/APIEndpoint.class.ts
@@ -255,7 +255,50 @@ export class APIEndpoint extends Component {
     // if (this.isOnAdvancedMode) {
     this.properties.defaultOutputs = ['headers', 'body', 'query'];
 
+    // Listen for endpoint changes to sync default values between input and output
+    this.on('endpointChanged', (entry, inputDiv, oldValue, newValue) => {
+      if (entry === 'defaultVal' && !this.isOnAdvancedMode) {
+        this.syncDefaultValue(inputDiv._outputDivElement, newValue);
+      }
+    });
+
     this._ready = true;
+  }
+
+  private syncDefaultValue(outputDiv: HTMLElement, defaultValue: string) {
+    if (!outputDiv) return;
+
+    if (defaultValue) {
+      outputDiv.setAttribute('smt-defaultVal', defaultValue);
+      outputDiv.setAttribute('title', `Default: ${defaultValue}`);
+    } else {
+      outputDiv.removeAttribute('smt-defaultVal');
+      outputDiv.removeAttribute('title');
+    }
+  }
+
+  private syncAllDefaultValues() {
+    if (this.isOnAdvancedMode) {
+      // Remove default values from outputs in advanced mode
+      this.domElement?.querySelectorAll('.output-endpoint').forEach((outputDiv: HTMLElement) => {
+        this.syncDefaultValue(outputDiv, '');
+      });
+    } else {
+      // Sync default values from inputs to outputs in compact mode
+      this.domElement?.querySelectorAll('.input-endpoint[smt-defaultVal]:not([smt-defaultVal=""])')
+        .forEach((inputDiv: HTMLElement) => {
+          const inputName = inputDiv.getAttribute('smt-name');
+          if (!this.properties.defaultOutputs.includes(inputName)) {
+            const outputDiv = this.domElement?.querySelector(`.output-endpoint[smt-name="${inputName}"]`) as HTMLElement;
+            if (outputDiv) {
+              const defaultValue = inputDiv.getAttribute('smt-defaultVal');
+              this.syncDefaultValue(outputDiv, defaultValue);
+              (inputDiv as any)._outputDivElement = outputDiv;
+              (outputDiv as any)._inputDivElement = inputDiv;
+            }
+          }
+        });
+    }
   }
 
   private async exposeIAChangeHandler(e) {
@@ -420,6 +463,9 @@ export class APIEndpoint extends Component {
     const outputParent = parent.parentElement.querySelector('.output-container');
     const inputProps = this.properties.inputProps?.find((c) => c.name === name);
 
+    // Get the default value from input properties or existing attributes
+    const defaultValue = inputProperties?.defaultVal || inputDiv.getAttribute('smt-defaultVal') || '';
+
     const outputDiv: any = await super.addOutput(
       outputParent,
       name,
@@ -442,6 +488,9 @@ export class APIEndpoint extends Component {
         },
       },
     );
+
+    // Pass the default value to the output endpoint
+    this.syncDefaultValue(outputDiv, defaultValue);
 
     if (inputProperties?.optional) {
       outputDiv.classList.add('marked-optional');
@@ -511,13 +560,13 @@ export class APIEndpoint extends Component {
       );
       optionalOutputs.forEach((output) => output.classList.remove('marked-optional'));
       // this.settings.method.readonly = false;
+
     } else {
       advancedItems.forEach((item) => item.classList.add('hidden'));
       // In simple mode, restore optional visual state for outputs from optional inputs
       const outputContainer = document.querySelector(`#${this.uid} .output-container`);
       if (outputContainer) {
-        const outputEndpoints = outputContainer.querySelectorAll('.output-endpoint');
-        outputEndpoints.forEach((outputDiv: HTMLElement) => {
+        outputContainer.querySelectorAll('.output-endpoint').forEach((outputDiv: HTMLElement) => {
           const linkedInputDiv = outputDiv['_inputDivElement'];
           if (linkedInputDiv) {
             const inputProps = this.properties.inputProps?.find(
@@ -529,8 +578,11 @@ export class APIEndpoint extends Component {
           }
         });
       }
-      // this.settings.method.readonly = true;
     }
+
+    // Sync default values based on current mode
+    this.syncAllDefaultValues();
+    // this.settings.method.readonly = true;
 
     // Handle method setting visibility for both initial setup and toggle changes
     if (changeEvent) {
@@ -833,5 +885,8 @@ export class APIEndpoint extends Component {
     endpointBall.style.backgroundColor = 'rgb(60, 137, 249)';
 
     titleWrapper.appendChild(endpointBall);
+
+    // Sync default values after redraw
+    setTimeout(() => this.syncAllDefaultValues(), 100);
   }
 }

--- a/packages/app/static/css/smyth-builder.css
+++ b/packages/app/static/css/smyth-builder.css
@@ -786,6 +786,56 @@ body.locked #agent-sidebar-root .restore-button {
   white-space: nowrap;
 }
 
+/* Default value badges for output endpoints (visible in compact mode) */
+.output-endpoint[smt-defaultval]:not([smt-defaultval=''])::before {
+  content: ' ';
+  display: block;
+  width: 40px;
+  border: 2px solid #bbb;
+  border-radius: 100px;
+  position: absolute;
+  bottom: 0px;
+  right: -38px;
+  height: 30px;
+  top: 10px;
+  z-index: 1;
+  clip-path: inset(0px -1px 11px 9px);
+}
+
+.output-endpoint[smt-defaultval]:not([smt-defaultval=''])::after {
+  content: attr(smt-defaultval);
+  background: #fff;
+  padding: 0px 5px;
+  border-radius: 10px;
+  max-width: 100px;
+  overflow: hidden;
+  position: absolute;
+  right: -20px;
+  font-weight: 700;
+  border: 2px solid #bbb;
+  font-size: 12px;
+  line-height: 14px;
+  color: #777;
+  top: 15px;
+  z-index: 2;
+  text-overflow: ellipsis;
+  transform: translateX(100%);
+  white-space: nowrap;
+}
+
+/* When output is connected, adjust the default value badge position */
+.output-endpoint.jtk-connected[smt-defaultval]:not([smt-defaultval=''])::after {
+  top: 5px;
+  right: unset;
+  border-width: 1px;
+  transform: translateX(-10px);
+  background-color: #eee;
+}
+
+.output-endpoint.jtk-connected[smt-defaultval]:not([smt-defaultval=''])::before {
+  display: none;
+}
+
 .input-endpoint:hover .ep {
   background: #ff9676;
 }


### PR DESCRIPTION
## 🎯 What’s this PR about?

 Show default value badges on Agent Skill outputs in compact mode

- Add CSS styling for output endpoint default value indicators
- Create helper methods to sync default values between input/output endpoints
- Reduce code duplication with centralized default value management
- Ensure default values are visible in both compact and advanced modes
---

## 📎 Related ClickUp Ticket

 https://app.clickup.com/t/86eudbn83

---

## 💻 Demo (optional)

https://sharing.clickup.com/clip/p/t8591381/13ea5bdc-d5ae-4cac-8872-256b8ed9cc6f/13ea5bdc-d5ae-4cac-8872-256b8ed9cc6f.webm?filename=screen-recording-2025-08-28-18%3A34.webm
---

## ✅ Checklist

- [✅] Self-reviewed the code
- [✅] Linked the correct ClickUp ticket
- [✅] Tested locally (MANDATORY)
- [ ] Marked as **Draft** if not ready for review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Default values now sync from inputs to corresponding outputs in compact mode, and are cleared in advanced mode.
  - Defaults automatically refresh when toggling modes and after redraws to keep the UI consistent.
  - Output endpoints inherit and display the current default when added.

- Style
  - Output endpoints show compact default-value badges, mirroring inputs, with readable positioning.
  - Connected outputs adjust badge placement for clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->