### PR TITLE
Fix: 86eun01cw : Builder/Component Cards - Spinners Incorrectly Showed When Settings Sidebar Open (Prod)

### DIFF
--- a/packages/app/src/builder-ui/components/Component.class/index.ts
+++ b/packages/app/src/builder-ui/components/Component.class/index.ts
@@ -2422,8 +2422,6 @@ export class Component extends EventEmitter {
         }
       }
 
-      if (!this.settingsOpen && this.loadingIcon) this.loadingIcon?.classList?.remove('hidden');
-
       if (this.settingsOpen) {
         this.closeSettings();
       } else {

--- a/packages/app/src/builder-ui/components/Component.class/settings-editor.ts
+++ b/packages/app/src/builder-ui/components/Component.class/settings-editor.ts
@@ -48,10 +48,6 @@ async function onComponentLoad(sidebar) {
   // Keep dynamic draft updates handled by sidebarEditValues(onDraft). Do not write to component data on input/change.
 
   component.emit('settingsOpened', sidebar, this);
-  if (this.loadingIcon) {
-    await new Promise((resolve) => setTimeout(resolve, 500));
-    this.loadingIcon?.classList?.add('hidden');
-  }
 }
 
 function onTemplateCreateLoad(sidebar) {


### PR DESCRIPTION



## 🎯 What’s this PR about?

Eliminated code that shows/hides the loading icon when opening component settings. This simplifies the settings editor logic and removes unnecessary UI updates.
---

## 📎 Related ClickUp Ticket

 https://app.clickup.com/t/86eun01cw

---

## 💻 Demo (optional)

https://sharing.clickup.com/clip/p/t8591381/e06bd9cb-cbc1-466d-8e80-61995beddd67/e06bd9cb-cbc1-466d-8e80-61995beddd67.webm?filename=screen-recording-2025-08-28-19%3A12.webm
---

## ✅ Checklist

- [✅] Self-reviewed the code
- [✅] Linked the correct ClickUp ticket
- [✅] Tested locally (MANDATORY)
- [ ] Marked as **Draft** if not ready for review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Refined loading indicator behavior in the builder UI to reduce flicker and unnecessary visibility.
  - The loading icon is no longer forcibly shown when component settings are closed.
  - Removed artificial delay and auto-hide when opening component settings, resulting in a smoother, more responsive settings panel experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->