### PR TITLE
Modals styling updates

### DIFF
--- a/packages/app/src/builder-ui/components/APIEndpoint.class.ts
+++ b/packages/app/src/builder-ui/components/APIEndpoint.class.ts
@@ -193,7 +193,7 @@ export class APIEndpoint extends Component {
                 btnNoLabel: 'Cancel',
                 btnYesLabel: 'Enable',
                 btnNoClass: 'hidden',
-                btnYesClass: 'h-[48px] rounded-lg px-8',
+                btnYesClass: 'rounded-lg px-8',
               },
             );
             if (saveBeforeClose) {

--- a/packages/app/src/builder-ui/components/Component.class/index.ts
+++ b/packages/app/src/builder-ui/components/Component.class/index.ts
@@ -1076,8 +1076,8 @@ export class Component extends EventEmitter {
       return (await confirm('Deleting Output. Are you sure ?', '', {
         btnYesLabel: 'Delete',
         btnNoLabel: 'Cancel',
-        btnYesClass: 'bg-smyth-red-500 border-smyth-red-500 h-[48px] rounded-lg px-8',
         btnNoClass: 'hidden',
+        btnYesType: 'danger',
       }))
         ? this.deleteEndpoint(outputDiv)
         : false;
@@ -1520,8 +1520,8 @@ export class Component extends EventEmitter {
       const _confirm = await confirm('Deleting Input. Are you sure ?', '', {
         btnYesLabel: 'Delete',
         btnNoLabel: 'Cancel',
-        btnYesClass: 'bg-smyth-red-500 border-smyth-red-500 h-[48px] rounded-lg px-8',
         btnNoClass: 'hidden',
+        btnYesType: 'danger',
       });
 
       if (_confirm) {
@@ -1725,8 +1725,8 @@ export class Component extends EventEmitter {
         'Settings Changed',
         'You have unsaved changes. Are you sure you want to discard your changes?',
         {
-          btnNoLabel: 'Discard Changes',
           btnYesLabel: 'Save Changes',
+          btnNoClass: 'hidden',
         },
       );
       if (saveBeforeClose) {
@@ -2412,10 +2412,9 @@ export class Component extends EventEmitter {
             'You have unsaved changes',
             'Are you sure you want to close this without saving?',
             {
-              btnNoLabel: 'Cancel',
               btnYesLabel: 'Discard Changes',
-              btnNoClass: 'h-[48px] rounded-lg px-8',
-              btnYesClass: 'h-[48px] rounded-lg px-8',
+              btnYesClass: 'rounded-lg px-8',
+              btnNoClass: 'hidden',
             },
           );
           if (!discard) return;
@@ -2635,7 +2634,8 @@ export class Component extends EventEmitter {
         {
           btnYesLabel: 'Delete',
           btnNoLabel: 'Cancel',
-          btnYesClass: 'bg-smyth-red-500 border-smyth-red-500 h-[48px] rounded-lg px-8',
+          // btnYesClass: 'bg-smyth-red-500 border-smyth-red-500 rounded-lg px-8',
+          btnYesType: 'danger',
           btnNoClass: 'hidden',
         },
       ));

--- a/packages/app/src/builder-ui/components/Component.class/settings-editor.ts
+++ b/packages/app/src/builder-ui/components/Component.class/settings-editor.ts
@@ -361,10 +361,9 @@ export async function closeSettings(component: Component, force = false) {
       'You have unsaved changes',
       'Are you sure you want to close this without saving?',
       {
-        btnNoLabel: 'Cancel',
         btnYesLabel: 'Discard Changes',
-        btnNoClass: 'h-[48px] rounded-lg px-8',
-        btnYesClass: 'h-[48px] rounded-lg px-8',
+        btnYesClass: 'rounded-lg px-8',
+        btnNoClass: 'hidden',
       },
     );
     if (!discard) return;
@@ -441,10 +440,9 @@ export async function editSettings(component: Component) {
       'You have unsaved changes',
       'Are you sure you want to close this without saving?',
       {
-        btnNoLabel: 'Cancel',
         btnYesLabel: 'Discard Changes',
-        btnNoClass: 'h-[48px] rounded-lg px-8',
-        btnYesClass: 'h-[48px] rounded-lg px-8',
+        btnYesClass: 'rounded-lg px-8',
+        btnNoClass: 'hidden',
       },
     );
 

--- a/packages/app/src/builder-ui/pages/builder/llm-embodiment.ts
+++ b/packages/app/src/builder-ui/pages/builder/llm-embodiment.ts
@@ -146,12 +146,8 @@ async function populateKeysList() {
             <p class="text-gray-700">Are you sure you want to revoke this API key? This action cannot be undone.</p>
           </div>
         `,
+        onCloseClick: function () {},
         actions: [
-          {
-            label: 'Cancel',
-            cssClass: SECONDARY_BUTTON_STYLE,
-            callback: () => {}, // Do nothing on cancel
-          },
           {
             label: 'Revoke Key',
             cssClass: PRIMARY_BUTTON_STYLE,
@@ -221,15 +217,10 @@ function attachCreateKeyBtn() {
             </div>
           </div>
         `,
+        onCloseClick: function (dialog) {
+          createKeyBtn.disabled = false;
+        },
         actions: [
-          {
-            label: 'Cancel',
-            cssClass: SECONDARY_BUTTON_STYLE,
-            callback: function (dialog) {
-              // Re-enable the create button
-              createKeyBtn.disabled = false;
-            },
-          },
           {
             label: 'Create',
             cssClass: PRIMARY_BUTTON_STYLE,

--- a/packages/app/src/builder-ui/ui/dialogs.ts
+++ b/packages/app/src/builder-ui/ui/dialogs.ts
@@ -1355,6 +1355,7 @@ export function confirm(
     btnYesLabel = 'Ok',
     btnNoLabel = 'Cancel',
     btnYesClass = '',
+    btnYesType = '',
     btnNoClass = '',
     btnYesCallback = (btnYes) => {},
   } = {},
@@ -1379,6 +1380,15 @@ export function confirm(
     if (btnYesLabel) {
       btnYes.innerHTML = btnYesLabel;
       btnYes.className += ` ${btnYesClass}`;
+
+      if (btnYesType === 'danger') {
+        btnYes.className += ` bg-smyth-red-500 border-smyth-red-500 rounded-lg px-8 hover:bg-red-600`;
+        btnYes.classList.remove(
+          'bg-smythos-blue-500',
+          'border-smythos-blue-500',
+          'hover:bg-smythos-blue-600',
+        );
+      }
     }
     if (btnNoLabel && btnNoLabel !== null) {
       btnNo.innerHTML = btnNoLabel;

--- a/packages/app/src/builder-ui/ui/tw-dialogs.ts
+++ b/packages/app/src/builder-ui/ui/tw-dialogs.ts
@@ -183,7 +183,7 @@ export async function twEditValues({
   for (let action of actions) {
     const button = document.createElement('button');
     dialogActions.appendChild(button);
-    button.className = `px-8 py-3 text-white transition-opacity rounded-lg w-full sm:w-auto ${
+    button.className = `px-8 py-[9px] text-white transition-opacity rounded-lg w-full sm:w-auto ${
       action.cssClass || PRIMARY_BUTTON_STYLE
     }`;
     button.innerHTML = action.label;

--- a/packages/app/src/builder-ui/workspace/SelectionActions.ts
+++ b/packages/app/src/builder-ui/workspace/SelectionActions.ts
@@ -115,8 +115,8 @@ export async function deleteSelectionWithConfirm(workspace: Workspace): Promise<
       {
         btnYesLabel: 'Delete',
         btnNoLabel: 'Cancel',
-        btnYesClass: 'bg-smyth-red-500 border-smyth-red-500 h-[48px] rounded-lg px-8',
         btnNoClass: 'hidden',
+        btnYesType: 'danger',
       },
     );
     if (!shouldDelete) return false;

--- a/packages/app/src/react/features/agent-settings/components/CapabilitiesWidget/triggers/SingleAgentSkillCallForm.tsx
+++ b/packages/app/src/react/features/agent-settings/components/CapabilitiesWidget/triggers/SingleAgentSkillCallForm.tsx
@@ -124,7 +124,7 @@ const SingleAgentSkillCallForm = ({ component }: Props) => {
               label={'Call Endpoint'}
               loading={callSkillMutation.isLoading}
               variant="primary"
-              className="h-[48px] px-8 rounded-lg"
+              className="px-8 rounded-lg"
             />
           </div>
         </Form>

--- a/packages/app/src/react/features/agent-settings/dialogs/ChatBot.tsx
+++ b/packages/app/src/react/features/agent-settings/dialogs/ChatBot.tsx
@@ -214,7 +214,7 @@ const ChatBotDialog = ({
               leaveTo="opacity-0 scale-95"
             >
               <div className="w-[80vw] max-w-[1000px]">
-                <Dialog.Panel className="w-full relative transform overflow-hidden rounded-2xl bg-white p-8 text-left align-middle shadow-xl transition-all">
+                <Dialog.Panel className="w-full relative transform overflow-hidden rounded-xl bg-white p-6 text-left align-middle shadow-xl transition-all">
                   <Dialog.Title className="text-xl font-semibold leading-6 text-[#1E1E1E] mb-4 flex justify-between items-center">
                     <span>Chatbot Configurations</span>
                     <IoClose className="cursor-pointer" size={24} onClick={() => closeModal()} />
@@ -1104,7 +1104,7 @@ const ChatBotDialog = ({
                               Icon={<Spinner classes="w-4 h-4 mr-2" />}
                               disabled={isSubmitting}
                               type="submit"
-                              className="px-8 h-[48px] rounded-lg"
+                              className="px-8 rounded-lg"
                             />
                           </div>
                         </Form>

--- a/packages/app/src/react/features/agent-settings/dialogs/ChatGpt.tsx
+++ b/packages/app/src/react/features/agent-settings/dialogs/ChatGpt.tsx
@@ -156,7 +156,7 @@ const ChatGptDialog = ({
               leaveTo="opacity-0 scale-95"
             >
               <div className="w-[70%] min-w-[600px] max-w-[1200px]">
-                <Dialog.Panel className="w-full relative transform overflow-hidden rounded-2xl bg-white p-8 text-left align-middle shadow-xl transition-all">
+                <Dialog.Panel className="w-full relative transform overflow-hidden rounded-xl bg-white p-6 text-left align-middle shadow-xl transition-all">
                   <Dialog.Title className="text-xl font-semibold leading-6 text-[#1E1E1E] mb-4 flex justify-between items-center">
                     <span>ChatGPT Configurations</span>
                     <IoClose className="cursor-pointer" size={24} onClick={() => closeModal()} />
@@ -479,7 +479,7 @@ const ChatGptDialog = ({
 
                           <div className="mt-8 flex justify-end w-full">
                             <Button
-                              className="w-[100px] h-[48px] rounded-lg"
+                              className="w-[100px] rounded-lg"
                               handleClick={() => submitForm(props.values)}
                               label="Save"
                               addIcon={isSubmitting}

--- a/packages/app/src/react/features/agent-settings/dialogs/FormPreview.tsx
+++ b/packages/app/src/react/features/agent-settings/dialogs/FormPreview.tsx
@@ -138,7 +138,7 @@ const FormPreviewDialog = ({
               leaveTo="opacity-0 scale-95"
             >
               <div className="w-[80vw] max-w-[1000px]">
-                <Dialog.Panel className="w-full relative transform overflow-hidden rounded-2xl bg-white p-8 text-left align-middle shadow-xl transition-all">
+                <Dialog.Panel className="w-full relative transform overflow-hidden rounded-xl bg-white p-6 text-left align-middle shadow-xl transition-all">
                   <Dialog.Title className="text-xl font-semibold leading-6 text-[#1E1E1E] mb-4 flex justify-between items-center">
                     <span>Form Preview Configuration</span>
                     <IoClose className="cursor-pointer" size={24} onClick={() => closeModal()} />
@@ -287,7 +287,7 @@ const FormPreviewDialog = ({
                               Icon={<Spinner classes="w-4 h-4 mr-2" />}
                               disabled={isSubmitting}
                               type="submit"
-                              className="px-8 h-[48px] rounded-lg"
+                              className="px-8 rounded-lg"
                             />
                           </div>
                         </Form>

--- a/packages/app/src/react/features/agent-settings/modals/chatbotCode.modal.tsx
+++ b/packages/app/src/react/features/agent-settings/modals/chatbotCode.modal.tsx
@@ -118,7 +118,7 @@ const ChatbotCodeSnippetModal = (props: Props) => {
             label="Copy"
             addIcon={true}
             Icon={<FaCopy className="mr-2" />}
-            className="w-[100px] h-[48px] rounded-lg ml-auto"
+            className="w-[100px] rounded-lg ml-auto"
           />
         </div>
       </div>

--- a/packages/app/src/react/features/agents/components/agentCard/modals/AgentDeleteConfirmationModal.tsx
+++ b/packages/app/src/react/features/agents/components/agentCard/modals/AgentDeleteConfirmationModal.tsx
@@ -28,14 +28,14 @@ export function AgentDeleteConfirmationModal({
       isOpen={isOpen}
       onClose={handleClose}
       applyMaxWidth={false}
-      panelWidthClasses="max-w-[540px] w-[calc(100vw_-_-20px)]"
+      panelWidthClasses="max-w-[600px] w-[calc(100vw_-_-20px)]"
       title="Are you sure you want to delete this agent?"
     >
       <div className="mt-6 space-y-6">
-        <div className="px-2 pt-4">
+        <div className="pt-4">
           <div className="flex justify-end items-center flex-row gap-2">
             <CustomButton
-              className="ml-auto h-[48px] rounded-lg"
+              className="ml-auto rounded-lg"
               handleClick={onConfirm}
               label={isDeleting ? 'Deleting...' : 'Delete'}
               addIcon

--- a/packages/app/src/react/features/builder/components/VariablesWidget.tsx
+++ b/packages/app/src/react/features/builder/components/VariablesWidget.tsx
@@ -2,7 +2,7 @@ import { Workspace } from '@src/builder-ui/workspace/Workspace.class';
 import { getAgent } from '@src/react/features/agent-settings/clients';
 import WidgetCard from '@src/react/features/agent-settings/components/WidgetCard';
 import * as agentSettingsUtils from '@src/react/features/agents/utils';
-import { GlobalVariableIcon } from '@src/react/shared/components/svgs';
+import { CloseIcon, GlobalVariableIcon } from '@src/react/shared/components/svgs';
 import { Input } from '@src/react/shared/components/ui/input';
 import { Button } from '@src/react/shared/components/ui/newDesign/button';
 import { Spinner } from '@src/react/shared/components/ui/spinner';
@@ -604,7 +604,19 @@ const VariablesWidget = ({ agentId, workspace }: { agentId: string; workspace: W
           className="mt-4 flex items-center justify-center rounded-lg border border-solid border-gray-200"
         >
           <div className="bg-[#FFFF] text-[#5A5A5A] rounded-xl p-6 w-full max-w-md modal-content">
-            <h2 className="text-base font-semibold mb-4">Save Key to the Vault</h2>
+            <div className="flex justify-between items-center mb-4">
+              <h2 className="text-base font-semibold">Save Key to the Vault</h2>
+              <button
+                onClick={(e) => {
+                  e?.stopPropagation();
+                  setShowAddKeyModal(false);
+                }}
+                className="text-gray-400 hover:text-gray-600 transition-colors"
+                aria-label="Close modal"
+              >
+                <CloseIcon width={16} height={16} />
+              </button>
+            </div>
 
             <div className="mb-4">
               <Input
@@ -630,15 +642,7 @@ const VariablesWidget = ({ agentId, workspace }: { agentId: string; workspace: W
               />
             </div>
 
-            <div className="flex justify-end gap-3">
-              <Button
-                label="Cancel"
-                variant="secondary"
-                handleClick={(e) => {
-                  e?.stopPropagation();
-                  setShowAddKeyModal(false);
-                }}
-              />
+            <div className="flex justify-end">
               <Button
                 label={'Save'}
                 variant="primary"

--- a/packages/app/src/react/features/vault/components/api-keys.tsx
+++ b/packages/app/src/react/features/vault/components/api-keys.tsx
@@ -1,4 +1,5 @@
 import { ApiKey } from '@react/features/vault/types/types';
+import ConfirmModal from '@react/shared/components/ui/modals/ConfirmModal';
 import { cn, copyTextToClipboard } from '@react/shared/utils/general';
 import { scopeOptions } from '@src/react/features/vault/helpers/vault.helper';
 import { Button } from '@src/react/shared/components/ui/button';
@@ -46,37 +47,23 @@ export const DeleteApiKeyDialog: FC<DeleteApiKeyDialogProps> = ({ isOpen, apiKey
     deleteKey();
   };
 
+  if (!isOpen) {
+    return null;
+  }
+
   return (
-    <Dialog
-      open={isOpen}
-      onOpenChange={(open) => {
-        if (!isLoading) {
-          onClose();
-        }
-      }}
-    >
-      <DialogContent>
-        <DialogHeader>
-          <DialogTitle>Are you sure?</DialogTitle>
-        </DialogHeader>
-        <div className="py-2">
-          <p className="text-sm text-muted-foreground">
-            This action cannot be undone. This will permanently delete the API key.
-          </p>
-        </div>
-        <DialogFooter className="gap-2">
-          <CustomButton
-            className="ml-auto h-[48px] rounded-lg"
-            handleClick={handleDelete}
-            label={isLoading ? 'Deleting...' : 'Delete'}
-            addIcon
-            Icon={<img className="mr-2" src="/img/icons/Delete-White.svg" />}
-            disabled={isLoading}
-            isDelete
-          />
-        </DialogFooter>
-      </DialogContent>
-    </Dialog>
+    <ConfirmModal
+      onClose={onClose}
+      label={isLoading ? 'Deleting...' : 'Delete'}
+      handleConfirm={handleDelete}
+      handleCancel={onClose}
+      message="Are you sure?"
+      lowMsg="This action cannot be undone. This will permanently delete the API key."
+      isLoading={isLoading}
+      width="max-w-[600px] w-[calc(100vw_-_-20px)]"
+      confirmBtnClasses="bg-red-600 hover:bg-red-700 text-white"
+      cancelLabel="Cancel"
+    />
   );
 };
 
@@ -327,10 +314,10 @@ export const UpdateApiKeyDialog: FC<UpdateApiKeyDialogProps> = ({
                       scope.value == 'APICall'
                         ? 3
                         : scope.value == 'HuggingFace'
-                        ? 2
-                        : scope.value == 'ZapierAction'
-                        ? 4
-                        : 1,
+                          ? 2
+                          : scope.value == 'ZapierAction'
+                            ? 4
+                            : 1,
                   }}
                 >
                   <Checkbox
@@ -370,7 +357,7 @@ export const UpdateApiKeyDialog: FC<UpdateApiKeyDialogProps> = ({
             handleClick={handleSubmit}
             disabled={isLoading || !isFormValid()}
             label={isLoading ? 'Saving...' : 'Save'}
-            className={cn('w-[100px] h-[48px]', 'rounded-lg')}
+            className={cn('w-[100px]', 'rounded-lg')}
           />
         </DialogFooter>
       </DialogContent>

--- a/packages/app/src/react/features/vault/components/create-enterprise-modal.tsx
+++ b/packages/app/src/react/features/vault/components/create-enterprise-modal.tsx
@@ -9,12 +9,12 @@ import {
   enterpriseModelService,
   providerService,
 } from '@react/features/vault/vault-business-logic';
+import ConfirmModal from '@react/shared/components/ui/modals/ConfirmModal';
 import ToolTip from '@src/react/shared/components/_legacy/ui/tooltip/tooltip';
 import { Checkbox } from '@src/react/shared/components/ui/checkbox';
 import {
   Dialog,
   DialogContent,
-  DialogFooter,
   DialogHeader,
   DialogTitle,
 } from '@src/react/shared/components/ui/dialog';
@@ -367,7 +367,7 @@ export function CreateEnterpriseModal({
                 variant="primary"
                 type="submit"
                 label="Next"
-                className="w-[100px] h-[48px] rounded-lg"
+                className="w-[100px] rounded-lg"
               />
             </div>
           </form>
@@ -625,37 +625,22 @@ export function DeleteEnterpriseModelModal({
 }: DeleteEnterpriseModelModalProps) {
   if (!model) return null;
 
+  if (!isOpen) {
+    return null;
+  }
+
   return (
-    <Dialog
-      open={isOpen}
-      onOpenChange={(open) => {
-        if (!open && !isProcessing) {
-          onClose();
-        }
-      }}
-    >
-      <DialogContent className="sm:max-w-[425px]">
-        <DialogHeader>
-          <DialogTitle>Delete Enterprise Model</DialogTitle>
-        </DialogHeader>
-        <div className="py-4">
-          <p className="text-sm text-muted-foreground">
-            Are you sure you want to delete the enterprise model "{model.name}"? This action cannot
-            be undone.
-          </p>
-        </div>
-        <DialogFooter className="gap-2">
-          <CustomButton
-            className="ml-auto h-[48px] rounded-lg"
-            handleClick={() => onConfirm(model)}
-            label={isProcessing ? 'Deleting...' : 'Delete'}
-            addIcon
-            Icon={<img className="mr-2" src="/img/icons/Delete-White.svg" />}
-            disabled={isProcessing}
-            isDelete
-          />
-        </DialogFooter>
-      </DialogContent>
-    </Dialog>
+    <ConfirmModal
+      onClose={onClose}
+      label={isProcessing ? 'Deleting...' : 'Delete'}
+      handleConfirm={() => onConfirm(model)}
+      handleCancel={onClose}
+      message="Delete Enterprise Model"
+      lowMsg={`Are you sure you want to delete the enterprise model "${model.name}"? This action cannot be undone.`}
+      isLoading={isProcessing}
+      width="max-w-[600px] w-[calc(100vw_-_-20px)]"
+      confirmBtnClasses="bg-red-600 hover:bg-red-700 text-white"
+      cancelLabel="Cancel"
+    />
   );
 }

--- a/packages/app/src/react/features/vault/components/user-models.tsx
+++ b/packages/app/src/react/features/vault/components/user-models.tsx
@@ -1,4 +1,5 @@
 import { UserModel } from '@react/features/vault/types/types';
+import ConfirmModal from '@react/shared/components/ui/modals/ConfirmModal';
 import { cn, copyTextToClipboard } from '@react/shared/utils/general';
 import { Button } from '@src/react/shared/components/ui/button';
 import {
@@ -124,7 +125,7 @@ function SetupModal({ isOpen, onClose, model, existingKey, isEdit }: SetupModalP
             handleClick={handleSubmit}
             disabled={isSaveDisabled}
             label={isLoading ? 'Saving...' : 'Save'}
-            className={cn('w-[100px] h-[48px] rounded-lg')}
+            className={cn('w-[100px] rounded-lg')}
           />
         </DialogFooter>
       </DialogContent>
@@ -158,37 +159,21 @@ const DeleteUserModelKeyDialog = ({
     );
   };
 
+  if (!isOpen) {
+    return null;
+  }
+
   return (
-    <Dialog
-      open={isOpen}
-      onOpenChange={(open) => {
-        if (!isLoading) {
-          onClose();
-        }
-      }}
-    >
-      <DialogContent>
-        <DialogHeader>
-          <DialogTitle>Are you sure?</DialogTitle>
-        </DialogHeader>
-        <div className="py-4">
-          <p className="text-sm text-muted-foreground">
-            This action cannot be undone. This will permanently delete the API key.
-          </p>
-        </div>
-        <DialogFooter className="gap-2">
-          <CustomButton
-            className="ml-auto h-[48px] rounded-lg"
-            handleClick={handleDelete}
-            label={isLoading ? 'Deleting...' : 'Delete'}
-            addIcon
-            Icon={<img className="mr-2" src="/img/icons/Delete-White.svg" />}
-            disabled={isLoading}
-            isDelete
-          />
-        </DialogFooter>
-      </DialogContent>
-    </Dialog>
+    <ConfirmModal
+      onClose={onClose}
+      label={isLoading ? 'Deleting...' : 'Delete'}
+      handleConfirm={handleDelete}
+      message="Are you sure?"
+      lowMsg="This action cannot be undone. This will permanently delete the API key."
+      isLoading={isLoading}
+      width="max-w-[600px] w-[calc(100vw_-_-20px)]"
+      confirmBtnClasses="bg-red-600 hover:bg-red-700 text-white"
+    />
   );
 };
 

--- a/packages/app/src/react/shared/components/layouts/RootLayout.tsx
+++ b/packages/app/src/react/shared/components/layouts/RootLayout.tsx
@@ -124,12 +124,14 @@ export const RootLayout = ({
           {useFullWidthLayout ? (
             <div
               className={classNames(
-                'absolute top-[-12px] left-0 h-[calc(100%+3rem)] w-[100%] rounded-none bg-[#FFF]')}
+                'absolute top-[-12px] left-0 h-[calc(100%+3rem)] w-[100%] rounded-none bg-[#FFF]',
+              )}
             ></div>
           ) : (
             <div
               className={classNames(
-                'absolute top-1 h-full ml-16 md:ml-auto w-[calc(100%-4.5rem)] md:w-[calc(100%-0.75rem)] rounded-t-lg border border-solid border-[#D1D1D1] bg-[#FFF]')}
+                'absolute top-1 h-full ml-16 md:ml-auto w-[calc(100%-4.5rem)] md:w-[calc(100%-0.75rem)] rounded-t-lg border border-solid border-[#D1D1D1] bg-[#FFF]',
+              )}
             ></div>
           )}
           <Suspense

--- a/packages/app/src/react/shared/components/ui/modals/ConfirmModal.tsx
+++ b/packages/app/src/react/shared/components/ui/modals/ConfirmModal.tsx
@@ -38,7 +38,9 @@ const ConfirmModal = (props: Props) => {
       >
         {/* Modal header */}
         <div className="flex flex-wrap justify-between items-start p-2 border-b dark:border-gray-600">
-          <h3 className="text-xl font-medium text-gray-900 dark:text-white">{props.message}</h3>
+          <h3 className="text-xl font-medium text-gray-900 dark:text-white w-[calc(100%_-_40px)]">
+            {props.message}
+          </h3>
           {props?.lowMsg && (
             <p className={classNames('text-sm text-gray-900', { 'pt-4': props.message })}>
               {props.lowMsg}
@@ -73,7 +75,7 @@ const ConfirmModal = (props: Props) => {
             <Button
               handleClick={props.handleConfirm}
               loading={props.isLoading}
-              className="h-[48px] px-8 rounded-lg"
+              className={classNames('px-8 rounded-lg', props.confirmBtnClasses)}
             >
               {props.label || 'Confirm'}
             </Button>

--- a/packages/app/src/react/shared/components/ui/modals/Modal.tsx
+++ b/packages/app/src/react/shared/components/ui/modals/Modal.tsx
@@ -68,7 +68,7 @@ const Modal = ({
               <div className={panelWrapperClasses}>
                 <Dialog.Panel
                   className={classNames(
-                    'transform rounded-2xl bg-white p-6 text-left align-middle shadow-xl transition-all',
+                    'transform rounded-xl bg-white p-6 text-left align-middle shadow-xl transition-all',
                     !panelWidthClasses ? (applyMaxWidth ? 'max-w-md' : 'max-w-full') : '',
                     panelClasses,
                     panelWidthClasses ? panelWidthClasses : 'w-full',

--- a/packages/app/views/pages/partials/dialog-secondary.ejs
+++ b/packages/app/views/pages/partials/dialog-secondary.ejs
@@ -38,7 +38,7 @@
     </button>
 
     <button
-      class="text-white text-center text-sm font-medium py-2 px-8 h-[48px] bg-smythos-blue-500 border-transparent hover:bg-smyth-blue rounded-lg border border-smyth-emerald-400 hover:opacity-75 focus:ring-4 focus:outline-none btn-submit"
+      class="text-white text-center text-base font-medium py-2 px-8 bg-smythos-blue-500 border-transparent hover:bg-smyth-blue rounded-lg border border-smyth-emerald-400 hover:opacity-75 focus:ring-4 focus:outline-none btn-submit"
     >
       Save
     </button>

--- a/packages/app/views/pages/partials/dialog.ejs
+++ b/packages/app/views/pages/partials/dialog.ejs
@@ -25,7 +25,7 @@
                 <div class="__content p-2">
                 </div>
                 <!-- Modal Footer -->
-                <div class="__actions px-4 pb-3 flex justify-end space-x-2">
+                <div class="__actions px-4 pb-4 flex justify-end space-x-2">
                     <!-- <button
                         class="__btnCancel px-3 py-1 bg-gray-400 text-white transition-opacity rounded-md w-full sm:w-auto hover:opacity-75">
                         Cancel </button>


### PR DESCRIPTION
## 🎯 What’s this PR about?
Modals across app styling updates
Related PR
https://github.com/SmythOS/smyth-ui-enterprise/pull/24
<!-- Brief summary of what this PR does -->

---

## 📎 Related ClickUp Ticket
https://app.clickup.com/t/86eun2pmd
<!-- Paste the link to the related ClickUp task -->
> Example: https://app.clickup.com/t/TEAM-123

---

## 💻 Demo (optional)

<!-- Link to deployed preview, video demo, or screenshots -->

---

## ✅ Checklist

- [ ] Self-reviewed the code
- [ ] Linked the correct ClickUp ticket
- [ ] Tested locally (MANDATORY)
- [ ] Marked as **Draft** if not ready for review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Standardized deletion confirmations using a consistent ConfirmModal with clear messages, loading states, and danger-styled confirm buttons.
  - Added header close buttons to Variables modals; removed separate Cancel actions.

- Style
  - Unified button styling: removed fixed heights, refined padding, and adopted danger emphasis for destructive actions.
  - Tightened modal visuals: smaller corner radius, reduced padding, adjusted footer spacing, and improved header layout to avoid overlap.
  - Minor width/typography tweaks across dialogs and panels.

- Refactor
  - Consolidated confirm flows and applied consistent danger styling; in select dialogs, hid Cancel/No to simplify choices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->