### PR TITLE
Update modal stylings.2

### DIFF
--- a/packages/app/src/builder-ui/pages/builder/agent-settings.ts
+++ b/packages/app/src/builder-ui/pages/builder/agent-settings.ts
@@ -881,10 +881,10 @@ export async function openPostmanEmbodiment() {
   const prodUrl = prodDomain ? `${scheme}://${prodDomain}/postman` : '';
 
   const testBtn = testUrl
-    ? `<div><a href="${testUrl}" target="_blank" class="flex items-center justify-center text-sm font-normal border border-solid text-base px-4 py-2 text-center rounded transition-all duration-200 outline-none focus:outline-none focus:ring-0 focus:ring-offset-0 focus:ring-shadow-none ${PRIMARY_BUTTON_STYLE}">Export Test Endpoints</a></div>`
+    ? `<div><a href="${testUrl}" target="_blank" class="flex items-center justify-center text-sm font-normal border border-solid text-base px-4 py-2 leading-none text-center rounded transition-all duration-200 outline-none focus:outline-none focus:ring-0 focus:ring-offset-0 focus:ring-shadow-none ${PRIMARY_BUTTON_STYLE}">Export Test Endpoints</a></div>`
     : '';
   const prodBtn = prodUrl
-    ? `<div><a href="${prodUrl}" target="_blank" class="flex items-center justify-center text-sm font-normal border border-solid text-base px-4 py-2 text-center rounded transition-all duration-200 outline-none focus:outline-none focus:ring-0 focus:ring-offset-0 focus:ring-shadow-none ${PRIMARY_BUTTON_STYLE}">Export Prod Endpoints</a></div>`
+    ? `<div><a href="${prodUrl}" target="_blank" class="flex items-center justify-center text-sm font-normal border border-solid text-base px-4 py-2 leading-none text-center rounded transition-all duration-200 outline-none focus:outline-none focus:ring-0 focus:ring-offset-0 focus:ring-shadow-none ${PRIMARY_BUTTON_STYLE}">Export Prod Endpoints</a></div>`
     : '';
 
   const content = `<div class="emb-instructions p-4 flex-row">

--- a/packages/app/src/builder-ui/pages/builder/llm-embodiment.ts
+++ b/packages/app/src/builder-ui/pages/builder/llm-embodiment.ts
@@ -1,4 +1,8 @@
-import { PRIMARY_BUTTON_STYLE, SECONDARY_BUTTON_STYLE } from '@src/react/shared/constants/style';
+import {
+  DELETE_BUTTON_STYLE,
+  PRIMARY_BUTTON_STYLE,
+  SECONDARY_BUTTON_STYLE,
+} from '@src/react/shared/constants/style';
 import { EMBODIMENT_DESCRIPTIONS, SMYTHOS_DOCS_URL } from '@src/shared/constants/general';
 import { isProdEnv } from '@src/shared/utils';
 import { setCodeEditor } from '../../ui/dom';
@@ -150,7 +154,7 @@ async function populateKeysList() {
         actions: [
           {
             label: 'Revoke Key',
-            cssClass: PRIMARY_BUTTON_STYLE,
+            cssClass: DELETE_BUTTON_STYLE,
             callback: async () => {
               revokeBtn.disabled = true;
               const agentId = workspace?.agent?.id;
@@ -620,7 +624,7 @@ print(response.choices)`,
 
   <div class="flex justify-center">
     <button id="create-new-key-btn"
-      class="flex items-center justify-center text-sm font-normal border border-solid text-base px-4 py-2 text-center rounded transition-all duration-200 outline-none focus:outline-none focus:ring-0 focus:ring-offset-0 focus:ring-shadow-none ${SECONDARY_BUTTON_STYLE} disabled:opacity-50 disabled:cursor-not-allowed">
+      class="h-8 flex items-center justify-center text-sm font-normal border border-solid text-base px-4 py-1 text-center rounded transition-all duration-200 outline-none focus:outline-none focus:ring-0 focus:ring-offset-0 focus:ring-shadow-none ${SECONDARY_BUTTON_STYLE} disabled:opacity-50 disabled:cursor-not-allowed">
       <svg class="w-4 h-4 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 4v16m8-8H4"/>
       </svg>

--- a/packages/app/src/react/features/agent-settings/components/SettingsWidget.tsx
+++ b/packages/app/src/react/features/agent-settings/components/SettingsWidget.tsx
@@ -161,7 +161,7 @@ const SettingsWidget = () => {
                 <Button
                   handleClick={handleModalClose}
                   type="button"
-                  className="h-[48px] px-8 rounded-lg ml-auto"
+                  className="px-8 rounded-lg ml-auto"
                 >
                   Done
                 </Button>

--- a/packages/app/src/react/features/agents/components/AgentsHeader.tsx
+++ b/packages/app/src/react/features/agents/components/AgentsHeader.tsx
@@ -1,6 +1,13 @@
 import HeaderSearch from '@react/shared/components/headerSearch';
 import { AscendingIcon, DescendingIcon } from '@react/shared/components/svgs';
 import { Button as CustomButton } from '@react/shared/components/ui/newDesign/button';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@react/shared/components/ui/select';
 import { Suspense } from 'react';
 
 import { SortOption } from '../types/agents.types';
@@ -55,21 +62,18 @@ export function AgentsHeader({
 
       <div className="w-max flex justify-between gap-2 flex-wrap flex-col sm:flex-row sm:flex-nowrap">
         <div className="flex items-center">
-          <select
-            id="sorting"
-            onChange={(e) => onSortCriteriaChange(e.target.value)}
-            value={sortCriteria}
-            className="w-36 border border-gray-300 text-gray-900 text-sm rounded
-             focus:ring-blue-500 focus:border-blue-500 block px-4 py-2
-              dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400
-               dark:text-white dark:focus:ring-blue-500 dark:focus:border-blue-500"
-          >
-            {SORT_FIELDS.map((s: SortOption) => (
-              <option key={s.value} value={s.value}>
-                {s.title}
-              </option>
-            ))}
-          </select>
+          <Select onValueChange={onSortCriteriaChange} value={sortCriteria}>
+            <SelectTrigger className="w-36">
+              <SelectValue placeholder="Select sort criteria" />
+            </SelectTrigger>
+            <SelectContent>
+              {SORT_FIELDS.map((s: SortOption) => (
+                <SelectItem key={s.value} value={s.value}>
+                  {s.title}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
 
           <button onClick={onSortOrderToggle} className="mx-2" aria-label="Sort agents">
             {sortOrder === 'asc' ? (

--- a/packages/app/src/react/features/agents/components/modals/deploy-agent-modal.tsx
+++ b/packages/app/src/react/features/agents/components/modals/deploy-agent-modal.tsx
@@ -752,7 +752,6 @@ function DeployAgentModal({ userInfo, deploymentSidebarCtx }) {
                               >
                                 here
                               </a>
-                              )
                             </span>
                           </div>
                           <div className="space-y-2">
@@ -776,7 +775,7 @@ function DeployAgentModal({ userInfo, deploymentSidebarCtx }) {
                           <Button
                             type="submit"
                             loading={isInProgress}
-                            className="h-[48px] px-8 rounded-lg ml-auto"
+                            className="px-8 rounded-lg ml-auto"
                           >
                             Deploy
                           </Button>
@@ -789,10 +788,7 @@ function DeployAgentModal({ userInfo, deploymentSidebarCtx }) {
                           Deploy on-prem or to enterprise cloud with enterprise security and
                           unlimited task options available. Great for enterprise.
                         </p>
-                        <Button
-                          className="h-[48px] px-8 rounded-lg ml-auto"
-                          handleClick={handleContactSales}
-                        >
+                        <Button className="rounded-lg ml-auto" handleClick={handleContactSales}>
                           Contact sales
                         </Button>
                       </div>
@@ -804,7 +800,7 @@ function DeployAgentModal({ userInfo, deploymentSidebarCtx }) {
                           local runtime for Mac, Windows, Linux.
                         </p>
                         <Button
-                          className="h-[48px] px-8 rounded-lg ml-auto"
+                          className="px-8 rounded-lg ml-auto"
                           handleClick={() => handleDeploy('locally')}
                         >
                           Download SRE

--- a/packages/app/src/react/features/embodiments/chatbot-embodiment-modal.tsx
+++ b/packages/app/src/react/features/embodiments/chatbot-embodiment-modal.tsx
@@ -38,11 +38,11 @@ export interface ChatbotEmbodimentModalProps {
  * @param {ChatbotEmbodimentModalProps} props - The component props.
  * @returns {JSX.Element} The rendered modal.
  */
-const ChatbotEmbodimentModal: React.FC<ChatbotEmbodimentModalProps> = ({ 
-  onClose, 
-  domain = 'your-domain.com', 
+const ChatbotEmbodimentModal: React.FC<ChatbotEmbodimentModalProps> = ({
+  onClose,
+  domain = 'your-domain.com',
   embodimentData,
-  isLoading = false
+  isLoading = false,
 }) => {
   const [copied, setCopied] = useState(false);
   const textareaRef = useRef<HTMLTextAreaElement>(null);
@@ -131,8 +131,8 @@ const ChatbotEmbodimentModal: React.FC<ChatbotEmbodimentModalProps> = ({
                 <p>
                   {!isUsingFullScreen ? (
                     <>
-                      Copy and paste this snippet into your website before the closing{' '}
-                      &lt;/body&gt; tag.
+                      Copy and paste this snippet into your website before the closing &lt;/body&gt;
+                      tag.
                     </>
                   ) : (
                     'Place this snippet inside a container DOM element, and the chatbot will occupy the full available space within it.'
@@ -148,14 +148,13 @@ const ChatbotEmbodimentModal: React.FC<ChatbotEmbodimentModalProps> = ({
                   className="w-full h-64 p-3 text-sm text-gray-800 bg-white rounded-lg border border-gray-200 font-mono resize-none focus:outline-none focus:border-b-2 focus:border-b-blue-500 transition-colors"
                   value={codeSnippet}
                 />
-                
+
                 {/* Copy Code button */}
                 <div className="flex justify-end">
                   <Button
                     variant="primary"
                     handleClick={handleCopyClick}
                     label={copied ? 'Copied' : 'Copy Code'}
-                    className="text-sm"
                     aria-label={copied ? 'Copied' : 'Copy code'}
                   />
                 </div>
@@ -168,4 +167,4 @@ const ChatbotEmbodimentModal: React.FC<ChatbotEmbodimentModalProps> = ({
   );
 };
 
-export default ChatbotEmbodimentModal; 
+export default ChatbotEmbodimentModal;

--- a/packages/app/src/react/features/embodiments/form-embodiment-modal.tsx
+++ b/packages/app/src/react/features/embodiments/form-embodiment-modal.tsx
@@ -185,7 +185,6 @@ const FormEmbodimentModal: FC<FormEmbodimentModalProps> = ({
                   variant="primary"
                   handleClick={handleCopyClick}
                   label={copied ? 'Copied' : 'Copy Code'}
-                  className="text-sm"
                   aria-label={copied ? 'Copied' : 'Copy code'}
                 />
               </div>

--- a/packages/app/src/react/features/embodiments/hooks/use-agent-endpoint-components.tsx
+++ b/packages/app/src/react/features/embodiments/hooks/use-agent-endpoint-components.tsx
@@ -16,7 +16,6 @@ export const useAgentEndpointComponents = (agentId?: string) => {
 
   // Use workspace data if available, otherwise use API data
   const agentData = workspaceData || apiData?.data;
-
   return {
     components:
       agentData?.components?.filter(

--- a/packages/app/src/react/features/embodiments/llm-embodiment-modal.tsx
+++ b/packages/app/src/react/features/embodiments/llm-embodiment-modal.tsx
@@ -469,7 +469,7 @@ const LlmEmbodimentModal: React.FC<LlmEmbodimentModalProps> = ({
             <Button
               label={copyState === 'copied' ? 'Copied' : 'Copy Code'}
               variant="primary"
-              className="px-4 py-1 text-xs"
+              className="px-4 py-2"
               handleClick={handleCopyCode}
               aria-label="Copy Code"
               type="button"
@@ -491,7 +491,7 @@ const LlmEmbodimentModal: React.FC<LlmEmbodimentModalProps> = ({
                     <Button
                       label="Create a new key"
                       variant="primary"
-                      className="px-6 py-2 text-sm"
+                      className="px-6 py-2"
                       handleClick={handleOpenCreateKey}
                       aria-label="Create a new key"
                       type="button"

--- a/packages/app/src/react/features/embodiments/modal-header-embodiment.tsx
+++ b/packages/app/src/react/features/embodiments/modal-header-embodiment.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { BackButtonWithTail, CloseIconWithoutPadding } from '../../shared/components/svgs';
+import { BackButtonWithTail, CloseIcon } from '../../shared/components/svgs';
 
 /**
  * Props for the ModalHeaderEmbodiment component.
@@ -62,11 +62,11 @@ const ModalHeaderEmbodiment: React.FC<ModalHeaderEmbodimentProps> = ({
       )}
       {/* Close button */}
       <button
-        className="absolute -right-2 -top-2 p-[6px] text-[#222] hover:bg-gray-100 rounded"
+        className="absolute -right-2 -top-2 p-2 text-[#222] hover:bg-gray-100 rounded"
         onClick={onClose}
         aria-label="Close"
       >
-        <CloseIconWithoutPadding width={12} height={12} />
+        <CloseIcon width={16} height={16} />
       </button>
     </div>
   );

--- a/packages/app/src/react/features/vault/components/api-keys.tsx
+++ b/packages/app/src/react/features/vault/components/api-keys.tsx
@@ -56,13 +56,11 @@ export const DeleteApiKeyDialog: FC<DeleteApiKeyDialogProps> = ({ isOpen, apiKey
       onClose={onClose}
       label={isLoading ? 'Deleting...' : 'Delete'}
       handleConfirm={handleDelete}
-      handleCancel={onClose}
       message="Are you sure?"
       lowMsg="This action cannot be undone. This will permanently delete the API key."
       isLoading={isLoading}
       width="max-w-[600px] w-[calc(100vw_-_-20px)]"
       confirmBtnClasses="bg-red-600 hover:bg-red-700 text-white"
-      cancelLabel="Cancel"
     />
   );
 };

--- a/packages/app/src/react/features/vault/components/create-enterprise-modal.tsx
+++ b/packages/app/src/react/features/vault/components/create-enterprise-modal.tsx
@@ -634,13 +634,11 @@ export function DeleteEnterpriseModelModal({
       onClose={onClose}
       label={isProcessing ? 'Deleting...' : 'Delete'}
       handleConfirm={() => onConfirm(model)}
-      handleCancel={onClose}
       message="Delete Enterprise Model"
       lowMsg={`Are you sure you want to delete the enterprise model "${model.name}"? This action cannot be undone.`}
       isLoading={isProcessing}
       width="max-w-[600px] w-[calc(100vw_-_-20px)]"
       confirmBtnClasses="bg-red-600 hover:bg-red-700 text-white"
-      cancelLabel="Cancel"
     />
   );
 }

--- a/packages/app/src/react/shared/components/ui/dialog.tsx
+++ b/packages/app/src/react/shared/components/ui/dialog.tsx
@@ -41,7 +41,7 @@ const DialogContent = React.forwardRef<
       {...props}
     >
       {children}
-      <DialogPrimitive.Close className="absolute right-6 top-6 p-2 rounded-lg hover:text-gray-900 hover:bg-gray-200 disabled:pointer-events-none data-[state=open]:bg-accent data-[state=open]:text-muted-foreground">
+      <DialogPrimitive.Close className="absolute right-6 top-6 p-2 rounded-lg hover:text-gray-900 hover:bg-gray-200 disabled:pointer-events-none data-[state=open]:bg-accent data-[state=open]:text-muted-foreground -mr-2">
         <CloseIcon width={16} height={16} />
         <span className="sr-only">Close</span>
       </DialogPrimitive.Close>

--- a/packages/app/src/react/shared/components/ui/input.tsx
+++ b/packages/app/src/react/shared/components/ui/input.tsx
@@ -71,7 +71,7 @@ const Input = React.forwardRef<HTMLInputElement, InputProps>(
           <input
             type={type}
             className={cn(
-              `h-9 w-full bg-white 
+              `h-[42px] w-full bg-white 
             border
             text-gray-900
             rounded
@@ -85,7 +85,7 @@ const Input = React.forwardRef<HTMLInputElement, InputProps>(
             font-normal
             placeholder:text-sm
             placeholder:font-normal`,
-              isSearch ? 'pl-10 pr-[10px] py-2' : 'px-[10px]',
+              isSearch ? 'pl-10 pr-[10px] py-0' : 'px-[10px]',
               error
                 ? '!border-[#C50F1F] focus:border-[#C50F1F]'
                 : 'border-gray-300 border-b-gray-500 focus:border-b-2 focus:border-b-blue-500 focus-visible:border-b-2 focus-visible:border-b-blue-500',

--- a/packages/app/src/react/shared/components/ui/modals/ConfirmModal.tsx
+++ b/packages/app/src/react/shared/components/ui/modals/ConfirmModal.tsx
@@ -48,7 +48,7 @@ const ConfirmModal = (props: Props) => {
           )}
           <button
             type="button"
-            className="absolute right-2 inline-flex items-center justify-center w-8 h-8 ml-auto text-sm text-gray-400 bg-transparent rounded-lg hover:text-gray-900 hover:bg-gray-200 dark:hover:bg-gray-600 dark:hover:text-white"
+            className="absolute right-2 inline-flex items-center justify-center w-8 h-8 ml-auto text-sm text-gray-400 bg-transparent rounded-lg hover:text-gray-900 hover:bg-gray-200 dark:hover:bg-gray-600 dark:hover:text-white -mr-2"
             onClick={props.onClose}
           >
             <CloseIcon width={16} height={16} />

--- a/packages/app/src/react/shared/components/ui/modals/Modal.tsx
+++ b/packages/app/src/react/shared/components/ui/modals/Modal.tsx
@@ -1,5 +1,5 @@
 import { Dialog, Transition } from '@headlessui/react';
-import { CloseIcon } from '@react/shared/components/svgs';
+import { BackButtonWithTail, CloseIcon } from '@react/shared/components/svgs';
 import classNames from 'classnames';
 import React, { Fragment } from 'react';
 
@@ -16,6 +16,7 @@ type Props = {
   panelWidthClasses?: string;
   panelWrapperClasses?: string;
   showOverflow?: boolean;
+  onBack?: () => void;
 };
 
 const Modal = ({
@@ -31,6 +32,7 @@ const Modal = ({
   panelWidthClasses = '',
   hideCloseIcon = false,
   showOverflow = false,
+  onBack,
 }: Props) => {
   return (
     <Transition appear show={isOpen} as={Fragment}>
@@ -77,14 +79,24 @@ const Modal = ({
                 >
                   <Dialog.Title as="h3" className="text-xl font-semibold leading-6 text-[#1E1E1E]">
                     <div className="flex items-center justify-between">
-                      <div>
-                        <span className="mb-1">{title}</span>
-                        {description && <p className="text-sm text-gray-500">{description}</p>}
+                      <div className="flex flex-col">
+                        <div className="flex items-center gap-1">
+                          {onBack && (
+                            <div
+                              className="cursor-pointer w-8 h-8 bg-transparent rounded-lg hover:text-gray-900 hover:bg-gray-200 p-2 flex items-center justify-center"
+                              onClick={onBack}
+                            >
+                              <BackButtonWithTail width={16} height={16} />
+                            </div>
+                          )}
+                          <span className="text-xl font-semibold text-[#1E1E1E]">{title}</span>
+                        </div>
+                        {description && <p className="text-sm text-gray-500 mt-1">{description}</p>}
                       </div>
 
                       {!hideCloseIcon && (
                         <div
-                          className="cursor-pointer w-8 h-8 bg-transparent rounded-lg hover:text-gray-900 hover:bg-gray-200 p-2"
+                          className="cursor-pointer w-8 h-8 bg-transparent rounded-lg hover:text-gray-900 hover:bg-gray-200 p-2 flex items-center justify-center"
                           onClick={(e) => {
                             e.stopPropagation();
                             onClose();

--- a/packages/app/src/react/shared/components/ui/newDesign/button.tsx
+++ b/packages/app/src/react/shared/components/ui/newDesign/button.tsx
@@ -32,7 +32,7 @@ interface CustomButtonProps {
   onMouseEnter?: (event: MouseEvent<HTMLButtonElement | HTMLAnchorElement>) => void;
   onMouseLeave?: (event: MouseEvent<HTMLButtonElement | HTMLAnchorElement>) => void;
   btnRef?: React.Ref<HTMLButtonElement>;
-  variant?: 'primary' | 'secondary' | 'tertiary' | 'quaternary';
+  variant?: 'primary' | 'secondary' | 'tertiary' | 'quaternary' | 'delete';
   isDelete?: boolean;
   iconPosition?: 'left' | 'right';
 }
@@ -78,6 +78,8 @@ export function Button({
           return TERTIARY_BUTTON_STYLE;
         case 'quaternary':
           return QUATERNARY_BUTTON_STYLE;
+        case 'delete':
+          return DELETE_BUTTON_STYLE;
         default:
           return PRIMARY_BUTTON_STYLE;
       }

--- a/packages/app/src/react/shared/components/ui/select.tsx
+++ b/packages/app/src/react/shared/components/ui/select.tsx
@@ -15,7 +15,7 @@ const SelectTrigger = React.forwardRef<
   <SelectPrimitive.Trigger
     ref={ref}
     className={cn(
-      'flex h-9 w-full items-center justify-between whitespace-nowrap rounded-md border border-input bg-transparent px-3 py-2 text-sm shadow-sm ring-offset-background placeholder:text-muted-foreground focus:outline-none focus:ring-1 focus:ring-ring disabled:cursor-not-allowed disabled:opacity-50 [&>span]:line-clamp-1',
+      'flex h-10 box-content w-full items-center justify-between whitespace-nowrap rounded-md border border-input bg-transparent px-3 text-sm shadow-sm ring-offset-background placeholder:text-muted-foreground focus:outline-none focus:ring-1 focus:ring-ring disabled:cursor-not-allowed disabled:opacity-50 [&>span]:line-clamp-1',
       className,
     )}
     {...props}

--- a/packages/app/views/pages/partials/dialog.ejs
+++ b/packages/app/views/pages/partials/dialog.ejs
@@ -13,10 +13,11 @@
 
 
                     <button class="__btnClose" aria-label="Close modal">
-                        <svg class="w-[20px] h-[20px]" fill="none" stroke="currentColor" viewBox="0 0 24 24"
-                            xmlns="http://www.w3.org/2000/svg">
-                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
-                                d="M6 18L18 6M6 6l12 12"></path>
+                        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+                            <path
+                                d="M20.7457 3.32851C20.3552 2.93798 19.722 2.93798 19.3315 3.32851L12.0371 10.6229L4.74275 3.32851C4.35223 2.93798 3.71906 2.93798 3.32854 3.32851C2.93801 3.71903 2.93801 4.3522 3.32854 4.74272L10.6229 12.0371L3.32856 19.3314C2.93803 19.722 2.93803 20.3551 3.32856 20.7457C3.71908 21.1362 4.35225 21.1362 4.74277 20.7457L12.0371 13.4513L19.3315 20.7457C19.722 21.1362 20.3552 21.1362 20.7457 20.7457C21.1362 20.3551 21.1362 19.722 20.7457 19.3315L13.4513 12.0371L20.7457 4.74272C21.1362 4.3522 21.1362 3.71903 20.7457 3.32851Z"
+                                fill="#0F0F0F"
+                            />
                         </svg>
                     </button>
 
@@ -67,11 +68,13 @@
                 <!-- Modal Header -->
                 <div class="bg-white text-[#1E1E1E] px-4 py-2 flex justify-between items-center">
                     <h2 class="__title text-xl font-semibold"></h2>
-                    <button class="__btnClose" aria-label="Close modal">
-                        <svg class="w-[20px] h-[20px]" fill="none" stroke="#666" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
-                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"></path>
-                        </svg>
-                    </button>
+                    <svg width="16" height="16" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+                        <path
+                            d="M20.7457 3.32851C20.3552 2.93798 19.722 2.93798 19.3315 3.32851L12.0371 10.6229L4.74275 3.32851C4.35223 2.93798 3.71906 2.93798 3.32854 3.32851C2.93801 3.71903 2.93801 4.3522 3.32854 4.74272L10.6229 12.0371L3.32856 19.3314C2.93803 19.722 2.93803 20.3551 3.32856 20.7457C3.71908 21.1362 4.35225 21.1362 4.74277 20.7457L12.0371 13.4513L19.3315 20.7457C19.722 21.1362 20.3552 21.1362 20.7457 20.7457C21.1362 20.3551 21.1362 19.722 20.7457 19.3315L13.4513 12.0371L20.7457 4.74272C21.1362 4.3522 21.1362 3.71903 20.7457 3.32851Z"
+                            fill="#0F0F0F"
+                        />
+                    </svg>
+
                 </div>
                 <!-- Modal Body -->
                 <div class="__content max-h-[60vh] overflow-y-auto scroll-smooth px-4">

--- a/packages/app/views/pages/partials/studio/feedback-modal.ejs
+++ b/packages/app/views/pages/partials/studio/feedback-modal.ejs
@@ -8,18 +8,16 @@
         <h2 class="text-xl font-semibold text-[#1E1E1E] mb-2">Leave Feedback</h2>
         <button class="__btnClose" id="cancelFeedback" aria-label="Close modal">
           <svg
-            class="w-[20px] h-[20px]"
-            fill="none"
-            stroke="currentColor"
+            width="16"
+            height="16"
             viewBox="0 0 24 24"
+            fill="none"
             xmlns="http://www.w3.org/2000/svg"
           >
             <path
-              stroke-linecap="round"
-              stroke-linejoin="round"
-              stroke-width="2"
-              d="M6 18L18 6M6 6l12 12"
-            ></path>
+              d="M20.7457 3.32851C20.3552 2.93798 19.722 2.93798 19.3315 3.32851L12.0371 10.6229L4.74275 3.32851C4.35223 2.93798 3.71906 2.93798 3.32854 3.32851C2.93801 3.71903 2.93801 4.3522 3.32854 4.74272L10.6229 12.0371L3.32856 19.3314C2.93803 19.722 2.93803 20.3551 3.32856 20.7457C3.71908 21.1362 4.35225 21.1362 4.74277 20.7457L12.0371 13.4513L19.3315 20.7457C19.722 21.1362 20.3552 21.1362 20.7457 20.7457C21.1362 20.3551 21.1362 19.722 20.7457 19.3315L13.4513 12.0371L20.7457 4.74272C21.1362 4.3522 21.1362 3.71903 20.7457 3.32851Z"
+              fill="#0F0F0F"
+            />
           </svg>
         </button>
       </div>


### PR DESCRIPTION
## 🎯 What’s this PR about?
Further updates for Modal ui styling 
Related PR: https://github.com/SmythOS/smyth-ui-enterprise/pull/30
<!-- Brief summary of what this PR does -->

---

## 📎 Related ClickUp Ticket
https://app.clickup.com/t/86eum0w2u
<!-- Paste the link to the related ClickUp task -->
> Example: https://app.clickup.com/t/TEAM-123

---

## 💻 Demo (optional)

<!-- Link to deployed preview, video demo, or screenshots -->

---

## ✅ Checklist

- [ ] Self-reviewed the code
- [ ] Linked the correct ClickUp ticket
- [ ] Tested locally (MANDATORY)
- [ ] Marked as **Draft** if not ready for review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added optional back button to modals for easier navigation.
  - Introduced a “Delete” button style and applied consistent destructive-action styling.
  - Upgraded Agents header sort to a polished Select dropdown.

- Style
  - Standardized button heights/paddings; adjusted input/select heights for better readability.
  - Updated close icons to filled 16px and refined close button spacing/alignment.
  - Minor text and spacing tweaks; Copy Code buttons sized for consistency.

- Bug Fixes
  - Removed stray characters and an extra parenthesis in modal markup to ensure valid rendering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->