### PR TITLE
Fix: 86eudbn83 : Adjust badge positioning for output endpoint

### DIFF
--- a/packages/app/static/css/smyth-builder.css
+++ b/packages/app/static/css/smyth-builder.css
@@ -811,6 +811,7 @@ body.locked #agent-sidebar-root .restore-button {
   overflow: hidden;
   position: absolute;
   right: -20px;
+  left: unset;
   font-weight: 700;
   border: 2px solid #bbb;
   font-size: 12px;
@@ -823,13 +824,21 @@ body.locked #agent-sidebar-root .restore-button {
   white-space: nowrap;
 }
 
-/* When output is connected, adjust the default value badge position */
+/* When output is connected, show badge on the left for compact mode */
 .output-endpoint.jtk-connected[smt-defaultval]:not([smt-defaultval=''])::after {
   top: 5px;
+  left: 8px;
   right: unset;
   border-width: 1px;
-  transform: translateX(-10px);
+  transform: translateX(0px);
   background-color: #eee;
+
+}
+
+/* Hide badge on hover to show buttons without overlap */
+.output-endpoint.jtk-connected[smt-defaultval]:not([smt-defaultval='']):hover::after {
+  opacity: 0;
+  visibility: hidden;
 }
 
 .output-endpoint.jtk-connected[smt-defaultval]:not([smt-defaultval=''])::before {


### PR DESCRIPTION


## 🎯 What’s this PR about?

Updated CSS to position the default value badge on the left for connected output endpoints in compact mode. Also added styles to hide the badge on hover to prevent overlap with buttons.
---

## 📎 Related ClickUp Ticket

https://app.clickup.com/t/86eudbn83

---

## 💻 Demo (optional)
https://sharing.clickup.com/clip/p/t8591381/8ab43b2a-73f9-4eef-bf58-e8df46582a4a/8ab43b2a-73f9-4eef-bf58-e8df46582a4a.webm?filename=screen-recording-2025-09-04-16%3A18.webm

---

## ✅ Checklist

- [✅] Self-reviewed the code
- [✅] Linked the correct ClickUp ticket
- [✅] Tested locally (MANDATORY)
- [ ] Marked as **Draft** if not ready for review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Restored correct positioning of the restore button when the interface is locked to ensure consistent access.

* **Style**
  * Default-value badge on connected outputs now appears on the left in compact mode with improved alignment for clearer readability.
  * Badge fades/hides on hover to reduce visual clutter while interacting with connections.
  * Overall UI tweaks enhance clarity without changing core functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->