### PR TITLE
"try debugging" behavior to auto-open debug modal

### DIFF
--- a/packages/app/src/builder-ui/components/Component.class/index.ts
+++ b/packages/app/src/builder-ui/components/Component.class/index.ts
@@ -2907,7 +2907,11 @@ export class Component extends EventEmitter {
     }
   }
 
-  public async openDebugDialog(event, operation: 'step' | 'run' = 'step') {
+  public async openDebugDialog(
+    event,
+    operation: 'step' | 'run' = 'step',
+    prefillValues?: Record<string, any>,
+  ) {
     PostHog.track('app_debug_inject_click', {});
     event.stopPropagation();
     event.stopImmediatePropagation();
@@ -2976,6 +2980,7 @@ export class Component extends EventEmitter {
           }
         },
         operation,
+        prefillValues,
       );
     });
   }

--- a/packages/app/src/builder-ui/debugger.ts
+++ b/packages/app/src/builder-ui/debugger.ts
@@ -2372,23 +2372,28 @@ export function createDebugInjectDialog(
   outputs,
   callback,
   operation: 'step' | 'run' = 'step',
+  prefillValues?: Record<string, any>,
 ) {
   const createInputList = (array, type) => {
     return array
       .map((el, index) => {
         if (el.type === 'file') {
+          const prefillValue = prefillValues?.[el.name] || '';
           return `
-            <div class="flex mb-5">
-              <span class="inline-flex w-40 items-center px-3 text-sm text-gray-900 bg-gray-200 border border-e-0 border-gray-300 rounded-s-md dark:bg-gray-600 dark:text-gray-400 dark:border-gray-600 break-all">
-                ${el.name}
-              </span>
-              <input type="file" name="${el.name}" id="${type}-input-${index}" class="${type}-input input
-                block w-full text-sm text-slate-500
-                file:mr-4 file:py-2 file:px-4 file:rounded-md
-                file:border-0 file:text-sm file:font-semibold
-                file:bg-gray-200 file:text-gray-900
-                hover:file:bg-gray-300 pl-5
-              " multiple>
+            <div class="mb-5">
+              <div class="flex">
+                <span class="inline-flex w-40 items-center px-3 text-sm text-gray-900 bg-gray-200 border border-e-0 border-gray-300 rounded-s-md dark:bg-gray-600 dark:text-gray-400 dark:border-gray-600 break-all">
+                  ${el.name}
+                </span>
+                <input type="file" name="${el.name}" id="${type}-input-${index}" class="${type}-input input
+                  block w-full text-sm text-slate-500
+                  file:mr-4 file:py-2 file:px-4 file:rounded-md
+                  file:border-0 file:text-sm file:font-semibold
+                  file:bg-gray-200 file:text-gray-900
+                  hover:file:bg-gray-300 pl-5
+                " multiple>
+              </div>
+              ${prefillValue ? `<div class="mt-2 text-xs text-gray-600">Previously selected: ${prefillValue.substring(0, 100)}${prefillValue.length > 100 ? '...' : ''}</div>` : ''}
             </div>`;
         } else {
           return `
@@ -2923,6 +2928,16 @@ export function createDebugInjectDialog(
       setupTooltip('#tooltip-container');
       setupTooltip('#default-values-tooltip');
       setupTooltip('#default-values-tooltip-outputs');
+
+      // Set prefill values if provided
+      if (prefillValues) {
+        inputs.forEach((input, index) => {
+          const inputElement: HTMLTextAreaElement = dialog.querySelector(`#inputs-input-${index}`);
+          if (inputElement && prefillValues[input.name] && inputElement.type !== 'file') {
+            inputElement.value = prefillValues[input.name].toString();
+          }
+        });
+      }
     },
   });
 

--- a/packages/app/src/react/features/builder/components/endpoint-form-preview-sidebar/views/ResponseView.tsx
+++ b/packages/app/src/react/features/builder/components/endpoint-form-preview-sidebar/views/ResponseView.tsx
@@ -15,6 +15,7 @@ const ResponseView = () => {
     lastResponse,
     mode,
     agentSkillErrors,
+    selectedSkill,
   } = useEndpointFormPreview();
 
   const [isCopied, setIsCopied] = useState(false);
@@ -141,12 +142,28 @@ const ResponseView = () => {
           Something went wrong? try{' '}
           <span
             className="font-semibold border-b border-solid pb-0.5 cursor-pointer text-blue-500 border-blue-500"
-            onClick={() => {
-              //Toggle debug bar
+            onClick={async () => {
+              // Toggle debug bar
               const debugSwitcher = document.querySelector('.debug-switcher');
               // trigger click on debug bar
               if (debugSwitcher && !debugSwitcher?.classList.contains('active')) {
                 debugSwitcher.dispatchEvent(new Event('click', { bubbles: true }));
+              }
+
+              // Open debug modal for the current skill
+              const componentElement = document.getElementById(selectedSkill?.skillId);
+              if (componentElement) {
+                const component = componentElement['_control'];
+                if (component && typeof component.openDebugDialog === 'function') {
+                  // Fire telemetry event
+                  const { PostHog } = await import('@src/shared/posthog');
+                  PostHog.track('debug_modal_opened', {
+                    source: 'test_as_form',
+                  });
+
+                  // Open the debug dialog with 'run' operation
+                  await component.openDebugDialog(new Event('click'), 'run', lastFormValues);
+                }
               }
             }}
           >


### PR DESCRIPTION
## 🎯 What’s this PR about?
Try debugging from form will open debug modal with values already filled with the one user already used
<!-- Brief summary of what this PR does -->

---

## 📎 Related ClickUp Ticket
https://app.clickup.com/t/86euqzm6g
<!-- Paste the link to the related ClickUp task -->
> Example: https://app.clickup.com/t/TEAM-123

---

## 💻 Demo (optional)
https://sharing.clickup.com/clip/p/t8591381/2c99c0ec-4a71-44bc-800c-e7420719547a/2c99c0ec-4a71-44bc-800c-e7420719547a.webm?filename=screen-recording-2025-09-04-19%3A02.webm
<!-- Link to deployed preview, video demo, or screenshots -->

---

## ✅ Checklist

- [ ] Self-reviewed the code
- [ ] Linked the correct ClickUp ticket
- [ ] Tested locally (MANDATORY)
- [ ] Marked as **Draft** if not ready for review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Debug dialog now supports pre-filled inputs, auto-populating fields when available.
  - File inputs display previously selected files for easier re-use.
  - From “Test as Form,” opening the debugger preloads your last form values for the selected skill, streamlining setup.
- Improvements
  - More robust handling when launching the debugger, gracefully falling back if required elements aren’t available.
- Chores
  - Added analytics event tracking when the debug modal is opened.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->