### PR TITLE
Share agent fix (better naming + register plugin correctly)

### DIFF
--- a/packages/app/src/react/shared/plugins/Plugins.ts
+++ b/packages/app/src/react/shared/plugins/Plugins.ts
@@ -11,6 +11,7 @@ export enum PluginTarget {
   BuilderSidebarComponentItems = 'builder/sidebarComponentItems',
   BuilderSREComponents = 'builder/sreComponents',
   AgentsPageSection = 'agentsPage/section',
+  ShareAgentWithUsers = 'builder/modals/ShareAgentWithUsers',
 }
 
 export enum PluginType {


### PR DESCRIPTION
## 🎯 What’s this PR about?
Share agent fix (better naming + register plugin correctly)
<!-- Brief summary of what this PR does -->
Related PR: https://github.com/SmythOS/smyth-ui-enterprise/pull/36
---

## 📎 Related ClickUp Ticket
https://app.clickup.com/t/86eujayb7
<!-- Paste the link to the related ClickUp task -->
> Example: https://app.clickup.com/t/TEAM-123

---

## 💻 Demo (optional)

<!-- Link to deployed preview, video demo, or screenshots -->

---

## ✅ Checklist

- [ ] Self-reviewed the code
- [ ] Linked the correct ClickUp ticket
- [ ] Tested locally (MANDATORY)
- [ ] Marked as **Draft** if not ready for review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Introduced a Share Agent modal that includes the agent’s name and opens only after you sign in.
- Bug Fixes
  - Share button now reliably enables/disables based on your authentication status.
  - Modal rendering is more stable, reducing intermittent issues and preventing access when not signed in.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->