### PR TITLE
padding + background update for X icon

### DIFF
--- a/packages/app/src/builder-ui/components/Component.class/index.ts
+++ b/packages/app/src/builder-ui/components/Component.class/index.ts
@@ -1425,7 +1425,7 @@ export class Component extends EventEmitter {
           // requires a tiny delay to make sure the input is focused
           delay(50).then(() => focusField(nameElm));
         },
-        contentClasses: 'min-h-[425px]',
+        contentClasses: 'min-h-[425px] px-2',
         dialogClasses: 'dialog-center rounded-[18px] p-2 pb-3',
         showCloseButton: true,
       });
@@ -2763,7 +2763,7 @@ export class Component extends EventEmitter {
         // requires a tiny delay to make sure the input is focused
         delay(50).then(() => focusField(nameElm));
       },
-      contentClasses: 'min-h-[425px]',
+      contentClasses: 'min-h-[425px] px-2',
       dialogClasses: 'dialog-center rounded-[18px] p-2 pb-3',
       showCloseButton: true,
     });

--- a/packages/app/src/builder-ui/ui/dialogs.ts
+++ b/packages/app/src/builder-ui/ui/dialogs.ts
@@ -2077,7 +2077,7 @@ export function openAgentSettingsRightSidebar(state = undefined) {
       const closeBtn = document.createElement('button');
       closeBtn.type = 'button';
       closeBtn.className =
-        'close-btn relative cursor-pointer w-8 h-8 bg-transparent rounded-lg hover:text-gray-900 hover:bg-gray-200 p-2 focus:z-10';
+        'close-btn relative cursor-pointer w-8 h-8 bg-transparent rounded-lg hover:text-gray-900 hover:bg-gray-100 p-2 focus:z-10';
       closeBtn.innerHTML = '<span class="mif-cross"></span>';
 
       // Add click event to close the sidebar

--- a/packages/app/src/react/features/agent-settings/components/CapabilitiesWidget/index.tsx
+++ b/packages/app/src/react/features/agent-settings/components/CapabilitiesWidget/index.tsx
@@ -160,7 +160,7 @@ function Endpoint({ component }: { component: Component }) {
 
               {/* Close button */}
               <div
-                className="absolute top-4 right-4 text-[#1E1E1E] hover:text-gray-500 cursor-pointer hover:bg-gray-100 rounded-lg p-2"
+                className="absolute top-4 right-4 text-[#1E1E1E] hover:text-gray-500 cursor-pointer hover:bg-gray-100 rounded-lg p-2 -mr-2 -mt-2"
                 onClick={() => setIsTriggeringSkill(false)}
               >
                 <CloseIcon width={16} height={16} />

--- a/packages/app/src/react/features/agent-settings/dialogs/ChatBot.tsx
+++ b/packages/app/src/react/features/agent-settings/dialogs/ChatBot.tsx
@@ -217,7 +217,7 @@ const ChatBotDialog = ({
                   <Dialog.Title className="text-xl font-semibold leading-6 text-[#1E1E1E] mb-4 flex justify-between items-center">
                     <span>Chatbot Configurations</span>
                     <div
-                      className="cursor-pointer w-8 h-8 bg-transparent rounded-lg hover:text-gray-900 hover:bg-gray-200 p-2"
+                      className="cursor-pointer w-8 h-8 bg-transparent rounded-lg hover:text-gray-900 hover:bg-gray-100 p-2 -mr-2 -mt-2"
                       onClick={() => closeModal()}
                     >
                       <CloseIcon width={16} height={16} />

--- a/packages/app/src/react/features/agent-settings/dialogs/ChatGpt.tsx
+++ b/packages/app/src/react/features/agent-settings/dialogs/ChatGpt.tsx
@@ -160,7 +160,7 @@ const ChatGptDialog = ({
                   <Dialog.Title className="text-xl font-semibold leading-6 text-[#1E1E1E] mb-4 flex justify-between items-center">
                     <span>ChatGPT Configurations</span>
                     <div
-                      className="cursor-pointer w-8 h-8 bg-transparent rounded-lg hover:text-gray-900 hover:bg-gray-200 p-2"
+                      className="cursor-pointer w-8 h-8 bg-transparent rounded-lg hover:text-gray-900 hover:bg-gray-100 p-2 -mr-2 -mt-2"
                       onClick={() => closeModal()}
                     >
                       <CloseIcon width={16} height={16} />

--- a/packages/app/src/react/features/agent-settings/dialogs/FormPreview.tsx
+++ b/packages/app/src/react/features/agent-settings/dialogs/FormPreview.tsx
@@ -142,7 +142,7 @@ const FormPreviewDialog = ({
                   <Dialog.Title className="text-xl font-semibold leading-6 text-[#1E1E1E] mb-4 flex justify-between items-center">
                     <span>Form Preview Configuration</span>
                     <div
-                      className="cursor-pointer w-8 h-8 bg-transparent rounded-lg hover:text-gray-900 hover:bg-gray-200 p-2"
+                      className="cursor-pointer w-8 h-8 bg-transparent rounded-lg hover:text-gray-900 hover:bg-gray-100 p-2 -mr-2 -mt-2"
                       onClick={() => closeModal()}
                     >
                       <CloseIcon width={16} height={16} />

--- a/packages/app/src/react/features/agent-settings/modals/chatbotCode.modal.tsx
+++ b/packages/app/src/react/features/agent-settings/modals/chatbotCode.modal.tsx
@@ -80,7 +80,7 @@ const ChatbotCodeSnippetModal = (props: Props) => {
           </h3>
           <button
             type="button"
-            className="inline-flex items-center justify-center w-8 h-8 ml-auto text-sm text-gray-400 bg-transparent rounded-lg hover:text-gray-900 hover:bg-gray-200 dark:hover:bg-gray-600 dark:hover:text-white -mr-2"
+            className="inline-flex items-center justify-center w-8 h-8 ml-auto text-sm text-gray-400 bg-transparent rounded-lg hover:text-gray-900 hover:bg-gray-100 dark:hover:bg-gray-600 dark:hover:text-white -mr-2"
             onClick={props.onClose}
           >
             <CloseIcon width={16} height={16} />

--- a/packages/app/src/react/features/agents/components/modals/deploy-agent-modal.tsx
+++ b/packages/app/src/react/features/agents/components/modals/deploy-agent-modal.tsx
@@ -545,7 +545,7 @@ function DeployAgentModal({ userInfo, deploymentSidebarCtx }) {
                   </div>
                   <div className="flex items-center gap-2">
                     <div
-                      className="text-[#1E1E1E] hover:text-gray-500 cursor-pointer hover:bg-gray-100 rounded-lg p-2"
+                      className="text-[#1E1E1E] hover:text-gray-500 cursor-pointer hover:bg-gray-100 rounded-lg p-2 -mr-2 -mt-2"
                       onClick={(e) => {
                         e.stopPropagation();
                         toggleDeployModal();
@@ -560,14 +560,6 @@ function DeployAgentModal({ userInfo, deploymentSidebarCtx }) {
                 <div className="relative bg-white rounded-2xl shadow-lg w-[480px] p-6 flex flex-col flex-none gap-2 overflow-auto max-h-[90vh]">
                   <div className="flex justify-between items-center mb-4">
                     <div className="flex items-center gap-2">
-                      {hasDeployment && (
-                        <div
-                          className="text-[#1E1E1E] hover:text-gray-500 cursor-pointer hover:bg-gray-100 rounded-lg p-2"
-                          onClick={handleCollapseModal}
-                        >
-                          <CloseIcon width={16} height={16} />
-                        </div>
-                      )}
                       <h2 className="text-xl font-semibold text-[#1E1E1E] flex items-center gap-1">
                         Deploy Agent
                         <Tooltip
@@ -594,7 +586,7 @@ function DeployAgentModal({ userInfo, deploymentSidebarCtx }) {
                       </h2>
                     </div>
                     <div
-                      className="text-[#1E1E1E] hover:text-gray-500 cursor-pointer hover:bg-gray-100 rounded-lg p-2"
+                      className="text-[#1E1E1E] hover:text-gray-500 cursor-pointer hover:bg-gray-100 rounded-lg p-2 -mr-2 -mt-2"
                       onClick={toggleDeployModal}
                     >
                       <CloseIcon width={16} height={16} />

--- a/packages/app/src/react/features/builder/components/VariablesWidget.tsx
+++ b/packages/app/src/react/features/builder/components/VariablesWidget.tsx
@@ -469,7 +469,7 @@ const VariablesWidget = ({ agentId, workspace }: { agentId: string; workspace: W
             </Tooltip>
             <Tooltip content="Close" placement="top">
               <div
-                className="cursor-pointer w-8 h-8 bg-transparent rounded-lg hover:text-gray-900 hover:bg-gray-200 p-2"
+                className="cursor-pointer w-8 h-8 bg-transparent rounded-lg hover:text-gray-900 hover:bg-gray-100 p-2"
                 onClick={(e) => {
                   e?.stopPropagation();
                   handleClose();

--- a/packages/app/src/react/shared/components/ui/dialog.tsx
+++ b/packages/app/src/react/shared/components/ui/dialog.tsx
@@ -41,7 +41,7 @@ const DialogContent = React.forwardRef<
       {...props}
     >
       {children}
-      <DialogPrimitive.Close className="absolute right-6 top-6 p-2 rounded-lg hover:text-gray-900 hover:bg-gray-200 disabled:pointer-events-none data-[state=open]:bg-accent data-[state=open]:text-muted-foreground -mr-2">
+      <DialogPrimitive.Close className="absolute right-6 top-6 p-2 rounded-lg hover:text-gray-900 hover:bg-gray-100 disabled:pointer-events-none data-[state=open]:bg-accent data-[state=open]:text-muted-foreground -mr-2">
         <CloseIcon width={16} height={16} />
         <span className="sr-only">Close</span>
       </DialogPrimitive.Close>

--- a/packages/app/src/react/shared/components/ui/modals/ConfirmModal.tsx
+++ b/packages/app/src/react/shared/components/ui/modals/ConfirmModal.tsx
@@ -48,7 +48,7 @@ const ConfirmModal = (props: Props) => {
           )}
           <button
             type="button"
-            className="absolute right-2 inline-flex items-center justify-center w-8 h-8 ml-auto text-sm text-gray-400 bg-transparent rounded-lg hover:text-gray-900 hover:bg-gray-200 dark:hover:bg-gray-600 dark:hover:text-white -mr-2"
+            className="absolute right-2 inline-flex items-center justify-center w-8 h-8 ml-auto text-sm text-gray-400 bg-transparent rounded-lg hover:text-gray-900 hover:bg-gray-100 dark:hover:bg-gray-600 dark:hover:text-white -mr-2 -mt-2"
             onClick={props.onClose}
           >
             <CloseIcon width={16} height={16} />

--- a/packages/app/src/react/shared/components/ui/modals/Modal.tsx
+++ b/packages/app/src/react/shared/components/ui/modals/Modal.tsx
@@ -83,7 +83,7 @@ const Modal = ({
                         <div className="flex items-center gap-1">
                           {onBack && (
                             <div
-                              className="cursor-pointer w-8 h-8 bg-transparent rounded-lg hover:text-gray-900 hover:bg-gray-200 p-2 flex items-center justify-center"
+                              className="cursor-pointer w-8 h-8 bg-transparent rounded-lg hover:text-gray-900 hover:bg-gray-100 p-2 flex items-center justify-center"
                               onClick={onBack}
                             >
                               <BackButtonWithTail width={16} height={16} />
@@ -96,7 +96,7 @@ const Modal = ({
 
                       {!hideCloseIcon && (
                         <div
-                          className="cursor-pointer w-8 h-8 bg-transparent rounded-lg hover:text-gray-900 hover:bg-gray-200 p-2 flex items-center justify-center"
+                          className="cursor-pointer w-8 h-8 bg-transparent rounded-lg hover:text-gray-900 hover:bg-gray-100 p-2 flex items-center justify-center -mr-2 -mt-2"
                           onClick={(e) => {
                             e.stopPropagation();
                             onClose();

--- a/packages/app/views/pages/partials/dialog-secondary.ejs
+++ b/packages/app/views/pages/partials/dialog-secondary.ejs
@@ -11,21 +11,21 @@
     <div class="dialog-title-text">Dialog Title</div>
     <button
       type="button"
-      class="js-dialog-close btn-close text-[#1E1E1E] bg-transparent hover:bg-gray-200 hover:text-gray-900 rounded-lg text-sm p-1.5 ml-auto inline-flex items-center dark:hover:bg-gray-600 dark:hover:text-white"
+      class="js-dialog-close btn-close text-[#1E1E1E] bg-transparent hover:bg-gray-100 hover:text-gray-900 rounded-lg text-sm p-1.5 ml-auto inline-flex items-center dark:hover:bg-gray-600 dark:hover:text-white"
     >
       <svg
-        aria-hidden="true"
-        class="w-5 h-5"
-        fill="currentColor"
-        viewBox="0 0 20 20"
+        width="16"
+        height="16"
+        viewBox="0 0 24 24"
+        fill="none"
         xmlns="http://www.w3.org/2000/svg"
       >
         <path
-          fill-rule="evenodd"
-          d="M4.293 4.293a1 1 0 011.414 0L10 8.586l4.293-4.293a1 1 0 111.414 1.414L11.414 10l4.293 4.293a1 1 0 01-1.414 1.414L10 11.414l-4.293 4.293a1 1 0 01-1.414-1.414L8.586 10 4.293 5.707a1 1 0 010-1.414z"
-          clip-rule="evenodd"
-        ></path>
+          d="M20.7457 3.32851C20.3552 2.93798 19.722 2.93798 19.3315 3.32851L12.0371 10.6229L4.74275 3.32851C4.35223 2.93798 3.71906 2.93798 3.32854 3.32851C2.93801 3.71903 2.93801 4.3522 3.32854 4.74272L10.6229 12.0371L3.32856 19.3314C2.93803 19.722 2.93803 20.3551 3.32856 20.7457C3.71908 21.1362 4.35225 21.1362 4.74277 20.7457L12.0371 13.4513L19.3315 20.7457C19.722 21.1362 20.3552 21.1362 20.7457 20.7457C21.1362 20.3551 21.1362 19.722 20.7457 19.3315L13.4513 12.0371L20.7457 4.74272C21.1362 4.3522 21.1362 3.71903 20.7457 3.32851Z"
+          fill="#0F0F0F"
+        />
       </svg>
+
       <span class="sr-only">Close modal</span>
     </button>
   </div>

--- a/packages/app/views/pages/partials/studio/dialog-confirm.ejs
+++ b/packages/app/views/pages/partials/studio/dialog-confirm.ejs
@@ -9,7 +9,7 @@
     <div class="relative p-4 text-center bg-white rounded-lg shadow dark:bg-gray-800 sm:p-5">
       <button
         type="button"
-        class="btn-close text-gray-400 absolute top-4 right-4 bg-transparent hover:bg-gray-200 hover:text-gray-900 rounded-lg text-sm p-2 ml-auto inline-flex items-center dark:hover:bg-gray-600 dark:hover:text-white"
+        class="btn-close text-gray-400 absolute top-4 right-4 bg-transparent hover:bg-gray-100 hover:text-gray-900 rounded-lg text-sm p-2 ml-auto inline-flex items-center dark:hover:bg-gray-600 dark:hover:text-white"
       >
         <svg
           width="16"

--- a/packages/app/views/pages/partials/studio/dialog-embodiment.ejs
+++ b/packages/app/views/pages/partials/studio/dialog-embodiment.ejs
@@ -1,21 +1,30 @@
-<div id="embodimentModal" tabindex="-1" aria-hidden="true"
-    class="bg-gray-800/50 overflow-y-auto overflow-x-hidden fixed top-0 right-0 left-0 z-40 w-full md:inset-0 md:h-full flex h-screen items-end justify-end hidden">
-    <div class="relative w-auto border-solid border-2 border-gray-400 h-[calc(100%-100px)]">
-        <!-- Modal content -->
-        <div class="modalBox relative bg-white  dark:bg-gray-800 h-[100%] ">
-            <button type="button"
-                class="z-10 btn-close text-gray-400 absolute top-2.5 right-2.5 bg-transparent hover:bg-gray-200 hover:text-gray-900 text-sm p-1.5 ml-auto inline-flex items-center dark:hover:bg-gray-600 dark:hover:text-white">
-
-                <svg aria-hidden="true" class="w-5 h-5" fill="currentColor" viewBox="0 0 20 20"
-                    xmlns="http://www.w3.org/2000/svg">
-                    <path fill-rule="evenodd"
-                        d="M4.293 4.293a1 1 0 011.414 0L10 8.586l4.293-4.293a1 1 0 111.414 1.414L11.414 10l4.293 4.293a1 1 0 01-1.414 1.414L10 11.414l-4.293 4.293a1 1 0 01-1.414-1.414L8.586 10 4.293 5.707a1 1 0 010-1.414z"
-                        clip-rule="evenodd"></path>
-                </svg>
-
-            </button>
-            <div class="content mb-4 text-gray-500 dark:text-gray-300 w-[100%] h-[100%]"></div>
-
-        </div>
+<div
+  id="embodimentModal"
+  tabindex="-1"
+  aria-hidden="true"
+  class="bg-gray-800/50 overflow-y-auto overflow-x-hidden fixed top-0 right-0 left-0 z-40 w-full md:inset-0 md:h-full flex h-screen items-end justify-end hidden"
+>
+  <div class="relative w-auto border-solid border-2 border-gray-400 h-[calc(100%-100px)]">
+    <!-- Modal content -->
+    <div class="modalBox relative bg-white dark:bg-gray-800 h-[100%]">
+      <button
+        type="button"
+        class="z-10 btn-close text-gray-400 absolute top-2.5 right-2.5 bg-transparent hover:bg-gray-100 hover:text-gray-900 text-sm p-1.5 ml-auto inline-flex items-center dark:hover:bg-gray-600 dark:hover:text-white"
+      >
+        <svg
+          width="16"
+          height="16"
+          viewBox="0 0 24 24"
+          fill="none"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M20.7457 3.32851C20.3552 2.93798 19.722 2.93798 19.3315 3.32851L12.0371 10.6229L4.74275 3.32851C4.35223 2.93798 3.71906 2.93798 3.32854 3.32851C2.93801 3.71903 2.93801 4.3522 3.32854 4.74272L10.6229 12.0371L3.32856 19.3314C2.93803 19.722 2.93803 20.3551 3.32856 20.7457C3.71908 21.1362 4.35225 21.1362 4.74277 20.7457L12.0371 13.4513L19.3315 20.7457C19.722 21.1362 20.3552 21.1362 20.7457 20.7457C21.1362 20.3551 21.1362 19.722 20.7457 19.3315L13.4513 12.0371L20.7457 4.74272C21.1362 4.3522 21.1362 3.71903 20.7457 3.32851Z"
+            fill="#0F0F0F"
+          />
+        </svg>
+      </button>
+      <div class="content mb-4 text-gray-500 dark:text-gray-300 w-[100%] h-[100%]"></div>
     </div>
+  </div>
 </div>

--- a/packages/app/views/pages/partials/studio/dialog-modal.ejs
+++ b/packages/app/views/pages/partials/studio/dialog-modal.ejs
@@ -8,7 +8,7 @@
     <div class="relative p-4 text-center bg-white rounded-lg shadow dark:bg-gray-800 sm:p-5">
       <button
         type="button"
-        class="btn-close absolute top-4 right-4 bg-transparent hover:bg-gray-200 hover:text-gray-900 rounded-lg text-sm p-2 ml-auto inline-flex items-center dark:hover:bg-gray-600 dark:hover:text-white"
+        class="btn-close absolute top-4 right-4 bg-transparent hover:bg-gray-100 hover:text-gray-900 rounded-lg text-sm p-2 ml-auto inline-flex items-center dark:hover:bg-gray-600 dark:hover:text-white"
       >
         <div class="img"></div>
         <span class="sr-only">Close modal</span>

--- a/packages/app/views/pages/partials/studio/feedback-modal.ejs
+++ b/packages/app/views/pages/partials/studio/feedback-modal.ejs
@@ -6,7 +6,11 @@
     >
       <div class="flex justify-between items-center">
         <h2 class="text-xl font-semibold text-[#1E1E1E] mb-2">Leave Feedback</h2>
-        <button class="__btnClose" id="cancelFeedback" aria-label="Close modal">
+        <button
+          class="__btnClose bg-transparent rounded-lg hover:text-gray-900 hover:bg-gray-100 p-2 -mr-2 -mt-2"
+          id="cancelFeedback"
+          aria-label="Close modal"
+        >
           <svg
             width="16"
             height="16"


### PR DESCRIPTION
## 🎯 What’s this PR about?
X icon padding + background colors

Related PR: https://github.com/SmythOS/smyth-ui-enterprise/pull/37
<!-- Brief summary of what this PR does -->

---

## 📎 Related ClickUp Ticket
https://app.clickup.com/t/86eumwv52
<!-- Paste the link to the related ClickUp task -->
> Example: https://app.clickup.com/t/TEAM-123

---

## 💻 Demo (optional)

<!-- Link to deployed preview, video demo, or screenshots -->

---

## ✅ Checklist

- [ ] Self-reviewed the code
- [ ] Linked the correct ClickUp ticket
- [ ] Tested locally (MANDATORY)
- [ ] Marked as **Draft** if not ready for review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Style
  - Unified hover states to a lighter tone for close/back buttons across dialogs and modals.
  - Improved close button alignment with subtle negative margins; added horizontal padding to editor dialogs for better spacing.
  - Refreshed close icon visuals in select templates for clearer, consistent appearance.
  - Minor layout tweaks to standardize header controls across light/dark modes.

- Refactor
  - Simplified the Deploy Agent modal by removing a redundant close control while preserving primary close behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->