### PR TITLE
Enhance security in debugger by implementing HTML escaping for conten…

### DIFF
--- a/packages/app/src/builder-ui/debugger.ts
+++ b/packages/app/src/builder-ui/debugger.ts
@@ -1288,7 +1288,6 @@ function showOutputInfo(outputEndpoint, outputContent, compName?) {
     ? getFormattedContent(outputContent, compName)
     : outputContent + '';
 
-  // Use innerHTML but with properly escaped content to maintain original structure
   div.innerHTML = `<button class="pin button primary"><span class="mif-pin icon"></span></button>${formattedContent}`;
   div.className = 'dbg-element dbg-output';
 
@@ -1356,7 +1355,6 @@ function showInputInfo(inputEndpoint, inputContent) {
 
   const formattedContent = getFormattedContent(inputContent);
 
-  // Use innerHTML but with properly escaped content to maintain original structure
   div.innerHTML = `<button class="pin button primary"><span class="mif-pin icon"></span></button>${formattedContent}`;
   div.className = 'dbg-element dbg-output';
 


### PR DESCRIPTION
…t rendering

- Updated `getFormattedContent` to escape HTML content, preventing XSS attacks when displaying web scrape output.
- Added inline comments to clarify the purpose of HTML escaping in the rendering process.
- Ensured consistent use of escaped content in `showOutputInfo` and `showInputInfo` functions to maintain original structure while enhancing security.

## 🎯 What’s this PR about?

<!-- Brief summary of what this PR does -->

---

## 📎 Related ClickUp Ticket

<!-- Paste the link to the related ClickUp task -->
> ClickUp: https://app.clickup.com/t/86eu40pwp

---

## 💻 Demo (optional)

<!-- Link to deployed preview, video demo, or screenshots -->

---

## ✅ Checklist

- [x] Self-reviewed the code
- [x] Linked the correct ClickUp ticket
- [x] Tested locally (MANDATORY)
- [ ] Marked as **Draft** if not ready for review
