### PR TITLE
Fix: 86eut80q3 : Note Component: Extra Space when markdown is selected

### DIFF
--- a/packages/app/static/css/smyth-components.css
+++ b/packages/app/static/css/smyth-components.css
@@ -248,8 +248,6 @@
 
 /* Base positioning for markdown content */
 .Note .note-markdown {
-  padding: 10px;
-  margin-top: 10px;
   overflow: auto;
   max-height: calc(100% - 120px);
   box-sizing: border-box;


### PR DESCRIPTION


## 🎯 What’s this PR about?

Eliminated the padding and top margin from the .Note .note-markdown CSS rule to adjust the layout and spacing of markdown content within notes.
---

## 📎 Related ClickUp Ticket

<!-- Paste the link to the related ClickUp task -->
> Example: https://app.clickup.com/t/86eut80q3

---

## 💻 Demo (optional)

https://sharing.clickup.com/clip/p/t8591381/f9fcb4b2-2b1c-4a26-9fd6-fadedfd3f392/f9fcb4b2-2b1c-4a26-9fd6-fadedfd3f392.webm?filename=screen-recording-2025-09-12-14%3A08.webm
---

## ✅ Checklist

- [✅] Self-reviewed the code
- [✅] Linked the correct ClickUp ticket
- [✅] Tested locally (MANDATORY)
- [ ] Marked as **Draft** if not ready for review
