### PR TITLE
Fix: 86euu09f7 : API Call Component/OAuth Section - Remove 'beta' Label in Production

### DIFF
--- a/packages/app/static/css/smyth-components.css
+++ b/packages/app/static/css/smyth-components.css
@@ -50,12 +50,6 @@
   height: 60px;
 }
 
-#collapse_toggle_OAuth::after {
-  content: 'beta';
-  color: #999;
-  font-size: 10px;
-  margin-top: -7px;
-}
 
 .component.Async .output-endpoint:not(.default) .name .label::before {
   content: '[ async ]';


### PR DESCRIPTION



## 🎯 What’s this PR about?

The 'beta' label previously shown on the OAuth collapse toggle has been removed from the CSS. This cleans up the UI by eliminating the outdated indicator.
---

## 📎 Related ClickUp Ticket

https://app.clickup.com/t/86euu09f7

---

## 💻 Demo (optional)

https://sharing.clickup.com/clip/p/t8591381/eed64001-b44a-4093-aefa-67b8b6f5982c/eed64001-b44a-4093-aefa-67b8b6f5982c.webm?filename=screen-recording-2025-09-12-14%3A29.webm
---

## ✅ Checklist

- [✅] Self-reviewed the code
- [✅] Linked the correct ClickUp ticket
- [✅] Tested locally (MANDATORY)
- [ ] Marked as **Draft** if not ready for review
