### PR TITLE
Fix: 86eur4kfz : Builder/Hover Window - Ctrl+C Keyboard Shortcut Not Copying Text (Production)

### DIFF
--- a/packages/app/src/builder-ui/workspace/hotkeys.ts
+++ b/packages/app/src/builder-ui/workspace/hotkeys.ts
@@ -7,6 +7,9 @@ import {
   canPaste,
   copySelection,
   deleteSelectionWithConfirm,
+  hasSelectedText,
+  isOverDebugOutput,
+  isSelectionInEditable,
 } from './SelectionActions';
 import { Workspace } from './Workspace.class';
 
@@ -71,8 +74,15 @@ export function registerHotkeys(workspace: Workspace) {
     //workspace.saveAgent();
   });
   hotkey(keys.copy, (event, handler) => {
+    // Allow native copy inside editable fields and debug/hover windows
+    if (isSelectionInEditable()) return; // let browser handle default copy
+    if (isOverDebugOutput() && hasSelectedText()) return; // let browser handle default copy
+
     if (!canCopy(workspace)) return false;
+    event.preventDefault();
+    event.stopPropagation();
     copySelection(workspace);
+    return false;
   });
   hotkey(keys.paste, async (event, handler) => {
     if (!(await canPaste(workspace))) return false;


### PR DESCRIPTION


## 🎯 What’s this PR about?


Enhances the logic for detecting when the user is interacting with debug output or hover windows, allowing native copy operations in those contexts. Updates hotkey handling to let the browser handle copy events when appropriate, and refines selection checks to improve user experience when copying text from debug areas.
---

## 📎 Related ClickUp Ticket

 https://app.clickup.com/t/86eur4kfz

---

## 💻 Demo (optional)

https://sharing.clickup.com/clip/p/t8591381/02d0fb84-2e96-42f1-85f0-d0b5131ff0db/02d0fb84-2e96-42f1-85f0-d0b5131ff0db.webm?filename=screen-recording-2025-09-12-15%3A05.webm
---

## ✅ Checklist

- [✅] Self-reviewed the code
- [✅] Linked the correct ClickUp ticket
- [✅] Tested locally (MANDATORY)
- [ ] Marked as **Draft** if not ready for review
