### PR TITLE
Fix: 86eutv8dy : Builder/Agent Connection - Connections Misaligned After Sorting and Refresh

### DIFF
--- a/packages/app/src/builder-ui/workspace/StateManager.class.ts
+++ b/packages/app/src/builder-ui/workspace/StateManager.class.ts
@@ -320,11 +320,22 @@ export class StateManager {
       //FIXME: find a better way to do wait for endpoints to be created
 
       let restorableConnections = [];
-      //combine saveConnections and state.remove?.connections and deduplicate them
+      // Combine connections captured before deletion with those recorded in state
       restorableConnections.push(...saveConnections, ...state.remove?.connections);
+      // Deduplicate using component ids AND endpoint indexes.
+      // Previously, we only keyed by sourceId/targetId which collapsed multiple edges
+      // between the same two components (e.g., Output[0]->Input[0], Output[1]->Input[1]).
+      // Including indexes guarantees each distinct edge is restored.
       restorableConnections = restorableConnections.filter(
         (c, index, self) =>
-          index === self.findIndex((t) => t.sourceId === c.sourceId && t.targetId === c.targetId),
+          index ===
+          self.findIndex(
+            (t) =>
+              t.sourceId === c.sourceId &&
+              t.targetId === c.targetId &&
+              t.sourceIndex === c.sourceIndex &&
+              t.targetIndex === c.targetIndex,
+          ),
       );
 
       //restore saved connections of updated components


### PR DESCRIPTION

## 🎯 What’s this PR about?


Connections are now deduplicated by both component IDs and endpoint indexes to prevent collapsing multiple edges between the same components. During import, endpoint names are resolved from saved component configs to ensure correct reconnection after input/output reordering, falling back to indices if names are unavailable.

---

## 📎 Related ClickUp Ticket

 https://app.clickup.com/t/86eutv8dy

---

## 💻 Demo (optional)


---

## ✅ Checklist

- [✅] Self-reviewed the code
- [✅] Linked the correct ClickUp ticket
- [✅] Tested locally (MANDATORY)
- [ ] Marked as **Draft** if not ready for review
