### PR TITLE
Add disabled state styles for boarding buttons in the popover

### DIFF
--- a/packages/app/static/css/smyth-builder.css
+++ b/packages/app/static/css/smyth-builder.css
@@ -2731,6 +2731,13 @@ body:not(:has(#upgrade-button-topbar)):has(#right-container.open #right-sidebar:
   border: none !important;
 }
 
+#boarding-popover-item .boarding-next-btn.boarding-disabled,
+#boarding-popover-item .boarding-prev-btn.boarding-disabled {
+  background-color: #cccccc !important;
+  color: #666666 !important;
+  opacity: 0.5 !important;
+}
+
 #boarding-popover-item .boarding-close-btn {
   font-size: 12px !important;
   font-weight: 500 !important;


### PR DESCRIPTION
## 🎯 What’s this PR about?

<!-- Brief summary of what this PR does -->

--- Add disabled state styles for boarding buttons in the popover

## 📎 Related ClickUp Ticket

<!-- Paste the link to the related ClickUp task -->
> Example: https://app.clickup.com/t/TEAM-123

--- https://app.clickup.com/t/86eunv3ev

## 💻 Demo (optional)

<!-- Link to deployed preview, video demo, or screenshots -->

---

## ✅ Checklist

- [ ] Self-reviewed the code
- [ ] Linked the correct ClickUp ticket
- [ ] Tested locally (MANDATORY)
- [ ] Marked as **Draft** if not ready for review
