### PR TITLE
Fix: Validation Warnings Show Too Early in Component Settings

### DIFF
--- a/packages/app/src/builder-ui/components/APICall.class.ts
+++ b/packages/app/src/builder-ui/components/APICall.class.ts
@@ -106,6 +106,7 @@ export class APICall extends Component {
         //validate: `required maxlength=${maxUriLength} ${isLocalhost ? 'url' : ''}`,
         validate: `required maxlength=${maxUriLength} custom=isUrlValid`,
         validateMessage: 'Provide a valid URL',
+        doNotValidateOnLoad: true,
         attributes: { 'data-template-vars': 'true' },
         cls: 'pr-4',
         help: `Enter the website address and add any path or query parts.\n <a href="${SMYTHOS_DOCS_URL}/agent-studio/components/advanced/api-call/?utm_source=studio&utm_medium=tooltip&utm_campaign=api-call&utm_content=url#step-1-choose-method-and-url" target="_blank" class="text-blue-600 hover:text-blue-800">See URL patterns</a>`,

--- a/packages/app/src/builder-ui/components/MCPClient.class.ts
+++ b/packages/app/src/builder-ui/components/MCPClient.class.ts
@@ -53,6 +53,7 @@ export class MCPClient extends Component {
         label: 'MCP URL',
         help: 'Enter the MCP server URL so the client can list the tools it offers.',
         validateMessage: 'MCP URL is required',
+        doNotValidateOnLoad: true,
       },
       prompt: {
         type: 'textarea',

--- a/packages/app/src/builder-ui/components/MemoryWriteKeyVal.class.ts
+++ b/packages/app/src/builder-ui/components/MemoryWriteKeyVal.class.ts
@@ -12,6 +12,7 @@ export class MemoryWriteKeyVal extends Component {
         validateMessage: 'Enter a non-empty name, not more than 100 characters.',
         attributes: { 'data-template-vars': 'true' },
         help: 'Stores the value under this namespace so other steps can find or remove it later.',
+        doNotValidateOnLoad: true,
       },
       key: {
         type: 'input',

--- a/packages/app/src/builder-ui/components/MemoryWriteObject.class.ts
+++ b/packages/app/src/builder-ui/components/MemoryWriteObject.class.ts
@@ -13,6 +13,7 @@ export class MemoryWriteObject extends Component {
         validateMessage: 'Enter a non-empty name, not more than 100 characters.',
         attributes: { 'data-template-vars': 'true' },
         help: 'Groups all saved keys under one namespace for consistent reads and deletes.',
+        doNotValidateOnLoad: true,
       },
       scope: {
         type: 'select',


### PR DESCRIPTION
- Updated APICall, MCPClient, MemoryWriteKeyVal, and MemoryWriteObject classes to include the 'doNotValidateOnLoad' property, ensuring validation does not occur on initial load for these components.

## 🎯 What’s this PR about?

<!-- Brief summary of what this PR does -->

--- Fix: Validation Warnings Show Too Early in Component Settings

## 📎 Related ClickUp Ticket

<!-- Paste the link to the related ClickUp task -->
> Example: https://app.clickup.com/t/TEAM-123

--- https://app.clickup.com/t/86euube8u

## 💻 Demo (optional)

<!-- Link to deployed preview, video demo, or screenshots -->

---

## ✅ Checklist

- [ ] Self-reviewed the code
- [ ] Linked the correct ClickUp ticket
- [ ] Tested locally (MANDATORY)
- [ ] Marked as **Draft** if not ready for review
