### PR TITLE
update styling for Breadcrumb Navigation Links

### DIFF
--- a/packages/app/static/css/smyth-global.css
+++ b/packages/app/static/css/smyth-global.css
@@ -1215,7 +1215,7 @@ html {
 
 /* Ensure tooltip links stay on one line */
 .tooltip a,
-[role="tooltip"] a,
+[role='tooltip'] a,
 .smt-hint a {
   white-space: nowrap !important;
   display: inline-block;
@@ -1226,7 +1226,7 @@ html {
 }
 
 .tooltip a:hover,
-[role="tooltip"] a:hover,
+[role='tooltip'] a:hover,
 .smt-hint a:hover {
   text-decoration: underline;
   opacity: 0.8;
@@ -1524,4 +1524,18 @@ textarea[class*='resize-none']::-webkit-resizer {
   opacity: 0 !important;
   width: 0 !important;
   height: 0 !important;
+}
+/**
+ * Breadcrumb link styling
+ * Override default link styling within breadcrumb navigation
+ * to ensure consistent gray color without underlines
+ */
+nav[aria-label='Breadcrumb'] a {
+  color: #6b7280; /* gray-500 */
+  text-decoration: none;
+}
+
+nav[aria-label='Breadcrumb'] a:hover {
+  color: #374151; /* gray-700 */
+  text-decoration: none;
 }


### PR DESCRIPTION
## 🎯 What’s this PR about?
minor styling update for breadcrumbs
<!-- Brief summary of what this PR does -->
Related PR: https://github.com/SmythOS/smyth-ui-enterprise/pull/104
---

## 📎 Related ClickUp Ticket
https://app.clickup.com/t/86ev6b9m9
<!-- Paste the link to the related ClickUp task -->
> Example: https://app.clickup.com/t/TEAM-123

---

## 💻 Demo (optional)
<img width="889" height="871" alt="image" src="https://github.com/user-attachments/assets/a9b4db61-0fbc-4572-9e47-6eebd2dcf545" />

<!-- Link to deployed preview, video demo, or screenshots -->

---

## ✅ Checklist

- [ ] Self-reviewed the code
- [ ] Linked the correct ClickUp ticket
- [ ] Tested locally (MANDATORY)
- [ ] Marked as **Draft** if not ready for review
