### PR TITLE
fix for error message shown when acquirelock fails

### DIFF
--- a/packages/app/src/builder-ui/Agent.class.ts
+++ b/packages/app/src/builder-ui/Agent.class.ts
@@ -150,7 +150,10 @@ export class Agent extends EventEmitter {
       //         })
       //         .catch(() => {});
       // } else {
-      await this.accquireLock(id);
+      const lockResult = await this.accquireLock(id);
+      if (lockResult && !lockResult.success && lockResult.errorCode === 'LOCKED_AGENT') {
+        return true;
+      }
       // }
 
       return true;


### PR DESCRIPTION
## 🎯 What’s this PR about?
acquirelock was showing toast message along side the error modal.
<!-- Brief summary of what this PR does -->

---

## 📎 Related ClickUp Ticket
https://app.clickup.com/t/86ev6bg6a
<!-- Paste the link to the related ClickUp task -->
> Example: https://app.clickup.com/t/TEAM-123

---

## 💻 Demo (optional)

<!-- Link to deployed preview, video demo, or screenshots -->

---

## ✅ Checklist

- [ ] Self-reviewed the code
- [ ] Linked the correct ClickUp ticket
- [ ] Tested locally (MANDATORY)
- [ ] Marked as **Draft** if not ready for review
