### PR TITLE
Fix: 86ev8vj3z : Feedback Modal - Inconsistent Validation on Feedback Submission

### DIFF
--- a/packages/app/views/pages/partials/studio/feedback-modal.ejs
+++ b/packages/app/views/pages/partials/studio/feedback-modal.ejs
@@ -120,7 +120,8 @@
       <div class="flex justify-end gap-3">
         <button
           id="submitFeedback"
-          class="flex items-center justify-center font-normal border border-solid text-base px-8 py-2 text-center rounded-lg transition-all duration-200 outline-none focus:outline-none focus:ring-0 focus:ring-offset-0 focus:ring-shadow-none bg-smythos-blue-500 text-white border-transparent hover:bg-smyth-blue"
+          class="flex items-center justify-center font-normal border border-solid text-base px-8 py-2 text-center rounded-lg transition-all duration-200 outline-none focus:outline-none focus:ring-0 focus:ring-offset-0 focus:ring-shadow-none bg-smythos-blue-500 text-white border-transparent hover:bg-smyth-blue disabled:opacity-50 disabled:cursor-not-allowed"
+          disabled
         >
           <span>Send</span>
           <div id="submitLoader" class="hidden ml-2">
@@ -162,9 +163,15 @@
 
   let selectedEmoji = null;
 
+  function updateSubmitButton() {
+    const hasText = feedbackTextarea?.value?.trim();
+    submitFeedback.disabled = !(hasText && selectedEmoji);
+  }
+
   function openFeedbackModal() {
     feedbackModal?.classList.remove('hidden');
     document.body.style.overflow = 'hidden';
+    updateSubmitButton();
   }
 
   function closeFeedbackModal() {
@@ -174,13 +181,12 @@
   }
 
   function resetFeedbackForm() {
-    if (feedbackTextarea) {
-      feedbackTextarea.value = '';
-    }
+    if (feedbackTextarea) feedbackTextarea.value = '';
     selectedEmoji = null;
     emojiButtons?.forEach((btn) => {
       btn.classList.remove('border-[#84CAFF]', 'bg-[#F5FAFF]', 'shadow-[0_0_0_4px_#EBF5FF]');
     });
+    updateSubmitButton();
   }
 
   async function submitToHubSpot(feedbackData) {
@@ -220,24 +226,17 @@
       submitLoader?.classList.remove('hidden');
       if (submitText) submitText.textContent = 'Sending...';
     } else {
-      if (submitBtn) submitBtn.disabled = false;
       if (cancelBtn) cancelBtn.disabled = false;
       submitLoader?.classList.add('hidden');
       if (submitText) submitText.textContent = 'Send';
+      updateSubmitButton();
     }
   }
 
   function validateFeedback(text, emoji) {
     const errors = [];
-
-    if (!text?.trim()) {
-      errors.push('Please enter your feedback');
-    }
-
-    if (!emoji) {
-      errors.push('Please select an emoji');
-    }
-
+    if (!text?.trim()) errors.push('Please enter your feedback');
+    if (!emoji) errors.push('Please select an emoji rating');
     return errors;
   }
 
@@ -249,7 +248,9 @@
     const errors = validateFeedback(feedbackText, selectedEmoji);
 
     if (errors.length > 0) {
-      toast?.(`${errors.join(' and ')}`, 'Error', 'alert');
+      if (typeof toast === 'function') {
+        toast(`${errors.join(' and ')}`, 'Error', 'alert');
+      }
       return;
     }
 
@@ -266,9 +267,14 @@
 
     if (result && result.success) {
       closeFeedbackModal();
-      toast?.('Thank you for your feedback!', 'Success', 'success');
+      if (typeof toast === 'function') {
+        toast('Thank you for your feedback!', 'Success', 'success');
+      }
+      console.log('Feedback submitted successfully to HubSpot');
     } else {
-      toast?.('Failed to submit feedback. Please try again.', 'Error', 'alert');
+      if (typeof toast === 'function') {
+        toast('Failed to submit feedback. Please try again.', 'Error', 'alert');
+      }
       console.error('Failed to submit feedback to HubSpot');
     }
   });
@@ -280,8 +286,11 @@
       });
       button.classList.add('border-[#84CAFF]', 'bg-[#F5FAFF]', 'shadow-[0_0_0_4px_#EBF5FF]');
       selectedEmoji = button.dataset?.emoji;
+      updateSubmitButton();
     });
   });
+
+  feedbackTextarea?.addEventListener('input', updateSubmitButton);
 
   feedbackModal?.addEventListener('click', (event) => {
     if (event?.target === feedbackModal) {


### PR DESCRIPTION
## 🎯 What’s this PR about?

The submit button in the feedback modal is now disabled by default and only enabled when both feedback text and an emoji are selected. Added updateSubmitButton logic to handle state changes, improved toast function checks, and ensured button state updates on relevant events for better UX and validation.
---

## 📎 Related ClickUp Ticket

 https://app.clickup.com/t/86ev8vj3z

---

## 💻 Demo (optional)

https://sharing.clickup.com/clip/p/t8591381/c24ad543-dc3a-4be2-9e06-9a83bfa5c60d/c24ad543-dc3a-4be2-9e06-9a83bfa5c60d.webm?filename=screen-recording-2025-10-27-15%3A53.webm

---

##  ✅ Checklist

- [✅] Self-reviewed the code
- [✅] Linked the correct ClickUp ticket
- [✅] Tested locally (MANDATORY)
- [ ] Marked as **Draft** if not ready for review
