### PR TITLE
Fix : 86ev85gfw : expand button position below textarea when error is displayed

### DIFF
--- a/packages/app/src/builder-ui/ui/form/createFormField.ts
+++ b/packages/app/src/builder-ui/ui/form/createFormField.ts
@@ -679,8 +679,11 @@ export default function createFormField(entry, displayType = 'block', entryIndex
     span.textContent = entry.validateMessage;
 
     // For expandable textareas, append the error message inside the wrapper
-    // so it's a sibling to the textarea element (which gets the .invalid class)
+    // Position it absolutely below the textarea so it doesn't push the expand button
     if (textareaWrapper) {
+      span.style.cssText = 'display: none; position: absolute; bottom: -24px; left: 0; font-size: 12px; color: #c50f1f; font-weight: 500;';
+      textareaWrapper.style.position = 'relative';
+      textareaWrapper.style.marginBottom = '24px';
       textareaWrapper.appendChild(span);
     } else {
       div.appendChild(span);


### PR DESCRIPTION

## 🎯 What’s this PR about?


Error messages for expandable textareas are now absolutely positioned below the textarea to avoid interfering with the expand button. The wrapper's position and margin are adjusted to accommodate the message.
---

## 📎 Related ClickUp Ticket

https://app.clickup.com/t/86ev85gfw

---

## 💻 Demo (optional)

https://sharing.clickup.com/clip/p/t8591381/b1108833-240b-4a02-8eeb-260cbbacffd8/b1108833-240b-4a02-8eeb-260cbbacffd8.webm?filename=screen-recording-2025-10-28-14%3A20.webm

---

## ✅ Checklist

- [✅] Self-reviewed the code
- [✅] Linked the correct ClickUp ticket
- [✅] Tested locally (MANDATORY)
- [ ] Marked as **Draft** if not ready for review
