### PR TITLE
Feature: 86ev83qcd : Add tooltips to API key action buttons

### DIFF
--- a/packages/app/src/react/features/vault/components/api-keys.tsx
+++ b/packages/app/src/react/features/vault/components/api-keys.tsx
@@ -442,42 +442,48 @@ export function ApiKeys({ pageAccess }: { pageAccess: { write: boolean } }) {
                     </td>
                     <td className="pl-4 py-2">
                       <div className="flex justify-end">
-                        <Button
-                          variant="ghost"
-                          size="sm"
-                          onClick={() => handleCopy(key.key, key.id)}
-                        >
-                          {copiedKeyId === key.id ? (
-                            <Check className="h-4 w-4 text-green-500" />
-                          ) : (
-                            <Copy className="h-4 w-4" />
-                          )}
-                        </Button>
-                        {pageAccess?.write && (
+                        <Tooltip content={copiedKeyId === key.id ? 'Copied!' : 'Copy'}>
                           <Button
                             variant="ghost"
                             size="sm"
-                            disabled={key.scope?.includes('CUSTOM_LLM')}
-                            onClick={() => {
-                              setSelectedKey(key);
-                              setEditModalOpen(true);
-                            }}
+                            onClick={() => handleCopy(key.key, key.id)}
                           >
-                            <Pencil className="h-4 w-4" />
+                            {copiedKeyId === key.id ? (
+                              <Check className="h-4 w-4 text-green-500" />
+                            ) : (
+                              <Copy className="h-4 w-4" />
+                            )}
                           </Button>
+                        </Tooltip>
+                        {pageAccess?.write && (
+                          <Tooltip content="Edit">
+                            <Button
+                              variant="ghost"
+                              size="sm"
+                              disabled={key.scope?.includes('CUSTOM_LLM')}
+                              onClick={() => {
+                                setSelectedKey(key);
+                                setEditModalOpen(true);
+                              }}
+                            >
+                              <Pencil className="h-4 w-4" />
+                            </Button>
+                          </Tooltip>
                         )}
                         {pageAccess?.write && (
-                          <Button
-                            variant="ghost"
-                            size="sm"
-                            disabled={key.scope?.includes('CUSTOM_LLM')}
-                            onClick={() => {
-                              setSelectedKey(key);
-                              setDeleteModalOpen(true);
-                            }}
-                          >
-                            <Trash2 className="h-4 w-4 hover:text-red-500" />
-                          </Button>
+                          <Tooltip content="Delete">
+                            <Button
+                              variant="ghost"
+                              size="sm"
+                              disabled={key.scope?.includes('CUSTOM_LLM')}
+                              onClick={() => {
+                                setSelectedKey(key);
+                                setDeleteModalOpen(true);
+                              }}
+                            >
+                              <Trash2 className="h-4 w-4 hover:text-red-500" />
+                            </Button>
+                          </Tooltip>
                         )}
                       </div>
                     </td>


### PR DESCRIPTION


## 🎯 What’s this PR about?

Wrapped the copy, edit, and delete buttons in tooltips to improve user experience and provide clearer action feedback in the API keys table.
---

## 📎 Related ClickUp Ticket

https://app.clickup.com/t/86ev83qcd

---

## 💻 Demo (optional)

https://sharing.clickup.com/clip/p/t8591381/346988d7-b7e5-458f-a7e4-9383d02183b9/346988d7-b7e5-458f-a7e4-9383d02183b9.webm?filename=screen-recording-2025-10-30-14%3A21.webm
---

## ✅ Checklist

- [✅] Self-reviewed the code
- [✅] Linked the correct ClickUp ticket
- [✅] Tested locally (MANDATORY)
- [ ] Marked as **Draft** if not ready for review
