### PR TITLE
Fix: 86ev83ufr : Improve Form preview right sidebar title layout and  truncation

### DIFF
--- a/packages/app/src/builder-ui/ui/right-sidebar-title.ts
+++ b/packages/app/src/builder-ui/ui/right-sidebar-title.ts
@@ -77,13 +77,13 @@ export const rightSidebarTitle = (title: string, tooltipText: string) => {
 
   const titleHTML = `
       <div class="flex items-center justify-between h-[72px] px-4 w-full">
-        <div class="flex items-center gap-2">
-          <span class="w-6 h-6 text-v2-gray-dark title-icon">${iconSvg}</span>
-          <span id="embodiment-sidebar-title" class="text-2xl font-semibold text-v2-gray-darker">${title}</span>
+        <div class="flex items-center gap-2 min-w-0 flex-1">
+          <span class="w-6 h-6 text-v2-gray-dark title-icon shrink-0">${iconSvg}</span>
+          <span id="embodiment-sidebar-title" class="text-2xl font-semibold text-v2-gray-darker truncate block min-w-0">${title}</span>
           ${
             tooltipText
               ? `
-            <div class="relative inline-block hidden">
+            <div class="relative inline-block hidden shrink-0">
               <svg class="w-4 h-4 text-gray-500 hover:text-gray-700 cursor-help"
                    data-tooltip-target="title-tooltip"
                    fill="none"
@@ -107,7 +107,7 @@ export const rightSidebarTitle = (title: string, tooltipText: string) => {
           }
         </div>
 
-         <div class="flex items-center gap-2">
+         <div class="flex items-center gap-2 shrink-0">
           <div class="dialog-actions actions m-0 order-none">
             <div class="action-buttons inline-flex justify-end px-0 m-0 align-middle">
               <div class="action-content flex"></div>

--- a/packages/app/views/pages/partials/studio/right-sidebar-emb.ejs
+++ b/packages/app/views/pages/partials/studio/right-sidebar-emb.ejs
@@ -6,8 +6,10 @@
 >
   <div class="container flex flex-col h-full">
     <div class="dialog-title flex">
-      <div class="inline-flex w-full overflow-visible" role="group">
-        <div class="title flex items-center flex-1 text-base font-semibold overflow-visible"></div>
+      <div class="inline-flex w-full overflow-hidden" role="group">
+        <div
+          class="title flex items-center flex-1 text-base font-semibold overflow-hidden min-w-0"
+        ></div>
 
         <!-- <div class="title-left-buttons inline-flex text-sm"></div>
         <div class="title-right-buttons inline-flex" dir="rtl">


### PR DESCRIPTION

## 🎯 What’s this PR about?


Updated CSS classes in right-sidebar-title.ts and right-sidebar-emb.ejs to better handle title truncation, overflow, and flex behavior. This ensures long titles are properly truncated and sidebar elements maintain layout integrity.

---

## 📎 Related ClickUp Ticket

https://app.clickup.com/t/86ev83ufr

---

## 💻 Demo (optional)

https://sharing.clickup.com/clip/p/t8591381/4a9a695b-3301-439e-8753-9b91dbdd7fd0/4a9a695b-3301-439e-8753-9b91dbdd7fd0.webm?filename=screen-recording-2025-10-30-15%3A09.webm
---

## ✅ Checklist

- [✅] Self-reviewed the code
- [✅] Linked the correct ClickUp ticket
- [✅] Tested locally (MANDATORY)
- [ ] Marked as **Draft** if not ready for review
