### PR TITLE
Fix: 86ev7ncwc : Remove Floating Border Expand/Collapse Element from Left Sidebar in smythOS

### DIFF
--- a/packages/app/views/pages/partials/studio/left-sidebar.ejs
+++ b/packages/app/views/pages/partials/studio/left-sidebar.ejs
@@ -543,21 +543,6 @@
     </div>
   </div>
 
-  <!-- Add new border div with tooltip -->
-  <div
-    class="absolute top-0 -right-5 w-1 h-full cursor-pointer transition-colors duration-200 z-[11] hover:bg-gray-200 group"
-    @click="toggleSidebar"
-    @mousemove="handleBorderMouseMove($event)"
-  >
-    <div
-      class="absolute bg-black text-white py-2 px-3 whitespace-nowrap pointer-events-none z-[52] rounded-lg text-sm text-center opacity-0 transition-opacity duration-300 group-hover:opacity-100"
-      :style="borderTooltipStyle"
-    >
-      <span class="font-bold" x-text="isSidebarOpen ? 'Collapse' : 'Expand'"></span>
-      <span class="text-gray-300"> Click</span>
-    </div>
-  </div>
-
   <%- include('agent-status'); -%>
 </div>
 
@@ -567,11 +552,6 @@
     const isChatPresent = urlParams.has('chat');
 
     Alpine.data('sidebarState', () => ({
-      borderTooltipStyle: {
-        top: '50%',
-        left: '15px',
-        transform: 'translate(0, -50%)',
-      },
       previousTab: localStorage.getItem('previousTab') || null,
       buildSidebarTabs: [
         'agentBuilderTab',
@@ -740,14 +720,6 @@
             localStorage.setItem('currentSidebarTab', this.currentSidebarTab);
           }
         }
-      },
-
-      handleBorderMouseMove(e) {
-        this.borderTooltipStyle = {
-          top: `${e.clientY}px`,
-          left: '15px',
-          transform: 'translate(0, -50%)',
-        };
       },
     }));
   });


### PR DESCRIPTION



## 🎯 What’s this PR about?

Deleted the border div with tooltip and associated Alpine.js state and event handler for sidebar border mouse movement. This simplifies the left sidebar UI and removes unused interactive elements.
---

## 📎 Related ClickUp Ticket

 https://app.clickup.com/t/86ev7ncwc

---

## 💻 Demo (optional)
https://sharing.clickup.com/clip/p/t8591381/6a010bdf-5d48-4126-89b2-9bc56af979f8/6a010bdf-5d48-4126-89b2-9bc56af979f8.webm?filename=screen-recording-2025-10-30-18%3A51.webm

---

## ✅ Checklist

- [✅] Self-reviewed the code
- [✅] Linked the correct ClickUp ticket
- [✅] Tested locally (MANDATORY)
- [ ] Marked as **Draft** if not ready for review
