### PR TITLE
Fix: 86ev7n9kz : Builder Page Sidebar - Navigation Links Open in Same Tab Instead of New Tab

### DIFF
--- a/packages/app/views/pages/partials/studio/builder-menu.ejs
+++ b/packages/app/views/pages/partials/studio/builder-menu.ejs
@@ -382,7 +382,7 @@
       >
         <ul class="block py-2">
           <li class="block w-full hover:bg-gray-100">
-            <a href="/" class="block px-4 py-2 text-sm text-gray-700">Home</a>
+            <a href="/" target="_blank" rel="noopener noreferrer" class="block px-4 py-2 text-sm text-gray-700">Home</a>
           </li>
           <li class="block w-full hover:bg-gray-100">
             <a

--- a/packages/app/views/pages/partials/studio/left-sidebar.ejs
+++ b/packages/app/views/pages/partials/studio/left-sidebar.ejs
@@ -24,6 +24,7 @@
 
       <a
         href="/"
+        target="_blank"
         rel="noopener noreferrer"
         class="flex items-center justify-center cursor-pointer transition-colors h-10 fill-gray-700 hover:fill-gray-700 hover:outline-none mb-2"
         data-tooltip-target="tooltip-agent"
@@ -273,6 +274,7 @@
       <div class="relative group home-btn">
         <a
           href="/"
+          target="_blank"
           rel="noopener noreferrer"
           id="home-button"
           class="relative w-full flex items-center h-10 justify-center"
@@ -302,6 +304,7 @@
       <div class="relative group vault-btn">
         <a
           href="/vault"
+          target="_blank"
           rel="noopener noreferrer"
           id="vault-button"
           class="relative w-full flex items-center h-10 justify-center"


### PR DESCRIPTION
## 🎯 What’s this PR about?

Added target="_blank" and rel="noopener noreferrer" to Home and Vault links in builder-menu and left-sidebar partials to ensure links open in a new tab and improve security.
---

## 📎 Related ClickUp Ticket

https://app.clickup.com/t/86ev7n9kz

---

## 💻 Demo (optional)

https://sharing.clickup.com/clip/p/t8591381/9ef65c01-b047-4df5-93b3-5be3912cf828/9ef65c01-b047-4df5-93b3-5be3912cf828.webm?filename=screen-recording-2025-11-03-18%3A47.webm
---

## ✅ Checklist

- [✅] Self-reviewed the code
- [✅] Linked the correct ClickUp ticket
- [✅] Tested locally (MANDATORY)
- [ ] Marked as **Draft** if not ready for review
