### PR TITLE
Fix: 86ev993wm : Remixing template should not default to 0,0

### DIFF
--- a/packages/app/src/builder-ui/workspace/Workspace.class.ts
+++ b/packages/app/src/builder-ui/workspace/Workspace.class.ts
@@ -651,7 +651,11 @@ export class Workspace extends EventEmitter {
       });
     }
 
-    if (this.agent.data?.ui?.panzoom) {
+    // Check if this is a remixed template - skip panzoom restoration if so
+    const params = new URLSearchParams(window.location.search);
+    const isRemixedTemplate = params.has('templateId');
+
+    if (this.agent.data?.ui?.panzoom && !isRemixedTemplate) {
       const zoomElement = document.getElementById('zoom');
       const origTransition = zoomElement.style.transition;
       zoomElement.style.transition = 'none';
@@ -1832,15 +1836,19 @@ export class Workspace extends EventEmitter {
     let requiresSave = false;
     let isFirstVisit = false;
 
+    // Check if this is a remixed template
+    const params = new URLSearchParams(window.location.search);
+    const isRemixedTemplate = params.has('templateId');
+
     let properties: ComponentProperties = {};
-    if (configuration?.ui?.agentCard) {
+    if (configuration?.ui?.agentCard && !isRemixedTemplate) {
       properties.left = configuration.ui.agentCard.left;
       properties.top = configuration.ui.agentCard.top;
     } else {
       const skills = configuration?.components?.filter((c) => c.name === 'APIEndpoint');
       // console.log('skills to compare', skills);
 
-      if (skills.length > 0) {
+      if (skills.length > 0 && !isRemixedTemplate) {
         // get the skill with the least Y and place the card above it to the left. x - agent_card_width, y - agent_card_height / 2
         const referenceSkill = skills
           // .map((s) => {
@@ -1857,6 +1865,7 @@ export class Workspace extends EventEmitter {
         requiresSave = true;
       } else {
         // handle first time loading - account for weaver sidebar being open
+        // Also treat remixed templates as first visit
         const isWeaverSidebarOpen =
           window?.localStorage?.getItem('currentSidebarTab') === 'agentBuilderTab';
         const sidebarOffset = isWeaverSidebarOpen ? 400 : 0;
@@ -1869,7 +1878,7 @@ export class Workspace extends EventEmitter {
     }
 
     this.agentCard = new AgentCard(this, properties, configuration);
-    if (isFirstVisit) {
+    if (isFirstVisit || isRemixedTemplate) {
       // it will always be triggered after initialization of the agent card since redraw() is an async operation (next tick)
       this.agentCard.addEventListener('AgentCardCreated', () => {
         this.scrollToAgentCard();


### PR DESCRIPTION


## 🎯 What’s this PR about?

Added checks for 'templateId' in URL parameters to identify remixed templates. Panzoom restoration and agent card positioning are now skipped or adjusted for remixed templates to ensure correct initial UI state.
---

## 📎 Related ClickUp Ticket

https://app.clickup.com/t/86ev993wm

---

## 💻 Demo (optional)

https://sharing.clickup.com/clip/p/t8591381/f51a8072-8f00-4149-be40-d450597104ca/f51a8072-8f00-4149-be40-d450597104ca.webm?filename=screen-recording-2025-11-04-14%3A05.webm
---

## ✅ Checklist

- [✅] Self-reviewed the code
- [✅] Linked the correct ClickUp ticket
- [✅] Tested locally (MANDATORY)
- [ ] Marked as **Draft** if not ready for review
