### PR TITLE
fix: ensure visibility of recent agents dropdown on hover

### DIFF
--- a/packages/app/src/builder-ui/pages/builder/agent-settings.ts
+++ b/packages/app/src/builder-ui/pages/builder/agent-settings.ts
@@ -1752,10 +1752,14 @@ function initializeRecentAgentsDropdown() {
   let isInitialized = false;
 
   dropdownTrigger?.addEventListener('mouseenter', async () => {
-    if (isInitialized) return;
-
     const dropdownContent = document.getElementById('recent-agents-dropdown');
     if (!dropdownContent) return;
+
+    // Always remove the hidden class on hover to ensure visibility
+    // (it may be added by other parts of the builder UI during changes)
+    dropdownContent.classList.remove('hidden');
+
+    if (isInitialized) return;
 
     const agents = await fetchRecentAgents();
 

--- a/packages/app/static/css/smyth-global.css
+++ b/packages/app/static/css/smyth-global.css
@@ -1106,6 +1106,14 @@ html {
   transition-delay: 0s;
 }
 
+/* Fix: Override hidden class on #recent-agents-dropdown when hovering over the new-agent-btn.
+   This ensures the agent list is visible even if 'hidden' class is dynamically added by other 
+   parts of the builder UI (e.g., during debug toggle or agent save operations). */
+.new-agent-btn:hover #recent-agents-dropdown,
+.new-agent-btn:hover #recent-agents-dropdown.hidden {
+  display: block !important;
+}
+
 /* Add smooth transition for dropdown items */
 .new-agent-btn .group .absolute {
   transform: translateX(10px);


### PR DESCRIPTION
## 🎯 What’s this PR about?

- Modified the event listener for the recent agents dropdown to always remove the 'hidden' class on mouse enter, ensuring the dropdown is visible even if the class is dynamically added elsewhere in the UI.
- Updated CSS to override the 'hidden' class when hovering over the new-agent button, maintaining the dropdown's visibility during various UI interactions.

---

## 📎 Related ClickUp Ticket

<!-- Paste the link to the related ClickUp task -->
> ClickUp: https://app.clickup.com/t/86ewgw8yf

---

## 💻 Demo (optional)

<!-- Link to deployed preview, video demo, or screenshots -->

---

## ✅ Checklist

- [x] Self-reviewed the code
- [x] Linked the correct ClickUp ticket
- [x] Tested locally (MANDATORY)
- [ ] Marked as **Draft** if not ready for review
