### PR TITLE
fix: improve chat error handling and display user-friendly context limit message

### DIFF
--- a/packages/app/src/react/features/ai-chat/components/chat/chat.tsx
+++ b/packages/app/src/react/features/ai-chat/components/chat/chat.tsx
@@ -25,7 +25,7 @@ export const Chat: FC<IProps> = memo((props) => {
     case MESSAGE_TYPES.INFO:
       return <Info message={content} />;
     case MESSAGE_TYPES.ERROR:
-      return <Error message={content} retry={retry} />;
+      return <Error message={content} retry={retry} isRetryable={props.isRetryable} />;
     default:
       return <Error message="Something went wrong!" retry={retry} />;
   }

--- a/packages/app/src/react/features/ai-chat/components/chat/message/error.tsx
+++ b/packages/app/src/react/features/ai-chat/components/chat/message/error.tsx
@@ -4,9 +4,9 @@ import { FC } from 'react';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 
-type TProps = TMessageProps & { retry: () => void };
+type TProps = TMessageProps & { retry: () => void; isRetryable?: boolean };
 
-export const Error: FC<TProps> = ({ message, retry }) => {
+export const Error: FC<TProps> = ({ message, retry, isRetryable = true }) => {
   const isApiKeyError =
     message.includes('Incorrect API key provided') ||
     (message.includes('401') &&
@@ -41,7 +41,7 @@ export const Error: FC<TProps> = ({ message, retry }) => {
             <ReactMarkdown remarkPlugins={[remarkGfm]}>{message}</ReactMarkdown>
           </div>
         </div>
-        {retry && (
+        {retry && isRetryable && (
           <button
             onClick={retry}
             className="inline-flex items-center px-4 gap-x-1 py-2 border border-gray-300 text-sm font-medium rounded-[18px] text-gray-700 bg-white hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 disabled:opacity-50 disabled:cursor-not-allowed transition-colors shadow-sm"

--- a/packages/app/src/react/features/ai-chat/hooks/use-chat-state.ts
+++ b/packages/app/src/react/features/ai-chat/hooks/use-chat-state.ts
@@ -178,11 +178,14 @@ export const useChatState = (options: TChatStateConfig): IChatState => {
     }
 
     setMessages((prev) => {
-      const filtered = prev.filter((msg) => msg.type !== MESSAGE_TYPES.LOADING);
+      const filtered = prev.filter(
+        (msg) => msg.type !== MESSAGE_TYPES.LOADING && msg.type !== MESSAGE_TYPES.META,
+      );
       const errorMessage: TChatMessage = {
         id: Date.now() + Math.random(),
         type: MESSAGE_TYPES.ERROR,
         content: error.message || 'An error occurred',
+        isRetryable: error.isRetryable,
         updatedAt: Date.now(),
       };
       return [...filtered, errorMessage];
@@ -209,23 +212,23 @@ export const useChatState = (options: TChatStateConfig): IChatState => {
 
           const userMessage: TChatMessage | null = shouldSetUserMessage
             ? {
-              id: msgCount + 1,
-              type: MESSAGE_TYPES.USER,
-              content: message?.trim() || '',
-              attachments:
-                currentAttachments.length > 0
-                  ? currentAttachments.map((a) => ({
-                    id: a.id,
-                    name: a.name,
-                    type: a.type,
-                    size: a.size,
-                    url: a.url,
-                    blobUrl: a.blobUrl,
-                    file: a.file,
-                  }))
-                  : undefined,
-              updatedAt: now,
-            }
+                id: msgCount + 1,
+                type: MESSAGE_TYPES.USER,
+                content: message?.trim() || '',
+                attachments:
+                  currentAttachments.length > 0
+                    ? currentAttachments.map((a) => ({
+                        id: a.id,
+                        name: a.name,
+                        type: a.type,
+                        size: a.size,
+                        url: a.url,
+                        blobUrl: a.blobUrl,
+                        file: a.file,
+                      }))
+                    : undefined,
+                updatedAt: now,
+              }
             : null;
 
           const loadingMessage: TChatMessage = {
@@ -247,16 +250,16 @@ export const useChatState = (options: TChatStateConfig): IChatState => {
             attachments:
               currentAttachments.length > 0
                 ? currentAttachments
-                  .filter((a) => a.file)
-                  .map((a) => ({
-                    id: `${Date.now()}_${Math.random()}`,
-                    file: a.file as File,
-                    name: a.name,
-                    type: a.type,
-                    size: a.size,
-                    url: a.url || '',
-                    metadata: {},
-                  }))
+                    .filter((a) => a.file)
+                    .map((a) => ({
+                      id: `${Date.now()}_${Math.random()}`,
+                      file: a.file as File,
+                      name: a.name,
+                      type: a.type,
+                      size: a.size,
+                      url: a.url || '',
+                      metadata: {},
+                    }))
                 : undefined,
             agentId,
             chatId,
@@ -287,6 +290,7 @@ export const useChatState = (options: TChatStateConfig): IChatState => {
         );
       } catch (error) {
         console.error('Error in sendMessage:', error); // eslint-disable-line no-console
+        // onStreamError(error as TChatError);
       } finally {
         setIsStreaming(false);
         abortRef.current = null;

--- a/packages/app/src/react/features/ai-chat/types/message.ts
+++ b/packages/app/src/react/features/ai-chat/types/message.ts
@@ -37,4 +37,5 @@ export type TChatMessage = {
   metaMessages?: TMetaMessage;
   updatedAt?: number;
   attachments?: TAttachment[];
+  isRetryable?: boolean;
 };

--- a/packages/app/src/react/features/ai-chat/types/stream.ts
+++ b/packages/app/src/react/features/ai-chat/types/stream.ts
@@ -44,6 +44,7 @@ export type TChatError = {
   type: TErrorType;
   originalError?: Error | unknown;
   isAborted?: boolean;
+  isRetryable?: boolean;
 };
 
 export type TAPIConfig = {


### PR DESCRIPTION
## 🎯 What’s this PR about?

<!-- Brief summary of what this PR does -->

- Fix plain TChatError objects being swallowed by handleStreamError, resulting in generic "An unexpected error occurred" instead of actual error messages
- Display user-friendly message when context limit is exceeded
- Add isRetryable flag to error/message types to control retry button visibility from the source (handleStreamError) instead of fragile string matching in UI
- Clean up LOADING and META messages on stream error (was only cleaning LOADING)

---

## 📎 Related ClickUp Ticket

<!-- Paste the link to the related ClickUp task -->
> https://app.clickup.com/t/86ewmup53

---

## 💻 Demo (optional)

<!-- Link to deployed preview, video demo, or screenshots -->

---

## ✅ Checklist

- [x] Self-reviewed the code
- [x] Linked the correct ClickUp ticket
- [x] Tested locally (MANDATORY)
- [ ] Marked as **Draft** if not ready for review
