### PR TITLE
fix: preserve whitespace chunks in stream to fix markdown heading rendering

### DIFF
--- a/packages/app/src/react/features/ai-chat/utils/stream.ts
+++ b/packages/app/src/react/features/ai-chat/utils/stream.ts
@@ -166,7 +166,7 @@ export const parseChunk = (chunk: TStreamChunk) => {
   const errorMessage = chunk.error || (chunk.isError ? chunk.content : null);
 
   return {
-    hasContent: Boolean(chunk.content && chunk.content.trim() !== ''),
+    hasContent: Boolean(chunk.content != null && chunk.content !== ''),
     content: chunk.content || '',
     hasMetaMessages: Boolean(
       chunk.debugOn ||


### PR DESCRIPTION
## 🎯 What’s this PR about?

<!-- Brief summary of what this PR does -->
Fixes markdown headings rendering as plain text in Chat/Chatbot UIs.

Root cause: `parseChunk()` used `.trim()` to validate content, which silently 
dropped whitespace-only chunks (e.g., `\n\n`). This caused headings to glue 
to previous text (e.g., `Q2## Executive Summary`), preventing react-markdown 
from parsing them as headings.

Fix: Changed `hasContent` check from `chunk.content.trim() !== ''` to 
`chunk.content !== ''` so newline chunks are preserved in the stream output.

---

## 📎 Related ClickUp Ticket

<!-- Paste the link to the related ClickUp task -->
> https://app.clickup.com/t/86ewq89f0

---

## 💻 Demo (optional)

<!-- Link to deployed preview, video demo, or screenshots -->

---

## ✅ Checklist

- [x] Self-reviewed the code
- [x] Linked the correct ClickUp ticket
- [x] Tested locally (MANDATORY)
- [ ] Marked as **Draft** if not ready for review
